### PR TITLE
Fix alumno duplicated validator

### DIFF
--- a/backend/src/main/java/ledance/validaciones/alumnos/ValidadorAlumnoDuplicado.java
+++ b/backend/src/main/java/ledance/validaciones/alumnos/ValidadorAlumnoDuplicado.java
@@ -16,9 +16,9 @@ public class ValidadorAlumnoDuplicado implements Validador<AlumnoRegistroRequest
 
     @Override
     public void validar(AlumnoRegistroRequest datos) {
-        if (alumnoRepositorio.existsByNombreIgnoreCaseAndApellidoIgnoreCase(datos.nombre(), datos.documento())) {
-            throw new RuntimeException("Alumno ya existe con ese nombre y apellido : "
-                    + datos.documento());
+        if (alumnoRepositorio.existsByNombreIgnoreCaseAndApellidoIgnoreCase(datos.nombre(), datos.apellido())) {
+            throw new RuntimeException("Alumno ya existe con ese nombre y apellido: "
+                    + datos.nombre() + " " + datos.apellido());
         }
     }
 }


### PR DESCRIPTION
## Summary
- correct apellido field usage in ValidadorAlumnoDuplicado
- update error message to include alumno's full name

## Testing
- `mvn -q package` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684df41f1d508324993e259fb7da7ec6