### PR TITLE
Fix typo in navigation item id

### DIFF
--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -150,8 +150,8 @@ export const navigationItems: NavigationItem[] = [
         icon: Receipt,
       },
       {
-        id: "correcion",
-        label: "Correcion",
+        id: "correccion",
+        label: "Correccion",
         href: "/pagos/editar",
         icon: DollarSign,
       },


### PR DESCRIPTION
## Summary
- rename `correcion` navigation item to `correccion`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684df41dd3748324afece911f7e308f9