### PR TITLE
Fix logical delete for Egresos

### DIFF
--- a/backend/src/main/java/ledance/servicios/egreso/EgresoServicio.java
+++ b/backend/src/main/java/ledance/servicios/egreso/EgresoServicio.java
@@ -66,7 +66,8 @@ public class EgresoServicio {
         Egreso egreso = egresoRepositorio.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Egreso no encontrado para id: " + id));
         // Realizamos una baja logica (marcandolo inactivo)
-        egresoRepositorio.delete(egreso);
+        egreso.setActivo(false);
+        egresoRepositorio.save(egreso);
     }
 
     public EgresoResponse obtenerEgresoPorId(Long id) {


### PR DESCRIPTION
## Summary
- fix logical deletion of `Egreso` records so they are marked inactive instead of removed

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df27780808324a2d8504bad4fea95