### PR TITLE
fix(ci): corrige baseline frontend y actualiza actions

### DIFF
--- a/.github/workflows/github.-actions-demo.yml
+++ b/.github/workflows/github.-actions-demo.yml
@@ -1,4 +1,4 @@
-name: CI Le Dance
+name: CI Gestudio
 
 on:
   workflow_dispatch:
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Java 21
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
         with:
           distribution: temurin
           java-version: "21"
@@ -37,7 +37,7 @@ jobs:
         run: bash ./mvnw -B -ntp clean verify
 
       - name: Set up Node 22.14.0
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22.14.0
           cache: npm
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout verified SHA
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Build backend image gate
         run: docker build --pull -t gestudio-backend:${{ github.sha }} ./backend
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout verified SHA
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Run isolated canonical smoke
         shell: pwsh

--- a/backend/src/test/java/gestudio/servicios/pdfs/ReciboStorageServiceTest.java
+++ b/backend/src/test/java/gestudio/servicios/pdfs/ReciboStorageServiceTest.java
@@ -1,0 +1,182 @@
+package gestudio.servicios.pdfs;
+
+import gestudio.entidades.Alumno;
+import gestudio.entidades.EstadoReciboPendiente;
+import gestudio.entidades.Pago;
+import gestudio.entidades.Recibo;
+import gestudio.entidades.ReciboPendiente;
+import gestudio.infra.configuracion.AppProperties;
+import gestudio.repositorios.AplicacionPagoRepositorio;
+import gestudio.repositorios.ReciboPendienteRepositorio;
+import gestudio.repositorios.ReciboRepositorio;
+import gestudio.servicios.email.IEmailService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReciboStorageServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-06-30T15:00:00Z");
+
+    @Mock private PdfService pdf;
+    @Mock private IEmailService email;
+    @Mock private ReciboPendienteRepositorio pendientes;
+    @Mock private ReciboRepositorio recibos;
+    @Mock private AplicacionPagoRepositorio aplicaciones;
+    @Mock private PlatformTransactionManager transactionManager;
+    @Mock private TransactionStatus transactionStatus;
+    @TempDir Path receiptsPath;
+
+    @BeforeEach
+    void transactions() {
+        when(transactionManager.getTransaction(any(TransactionDefinition.class))).thenReturn(transactionStatus);
+    }
+
+    @Test
+    void procesaUnaVezArchivoYEmailYCompletaElTrabajo() throws Exception {
+        Pago pago = pago("alumno@example.test");
+        Recibo recibo = recibo(pago);
+        ReciboPendiente trabajo = trabajo(pago, 0);
+        byte[] bytes = "pdf-test".getBytes();
+        when(pendientes.findClaimableForUpdate(any(Instant.class), eq(10)))
+                .thenReturn(List.of(trabajo))
+                .thenReturn(List.of());
+        when(pendientes.findByIdAndClaimToken(eq(1L), any(UUID.class)))
+                .thenAnswer(invocation -> Optional.of(trabajo));
+        when(recibos.findByPagoId(7L)).thenReturn(Optional.of(recibo));
+        when(aplicaciones.findByPagoIdOrderById(7L)).thenReturn(List.of());
+        when(pdf.generarReciboPdf(pago)).thenReturn(bytes);
+
+        service().procesarPendientes();
+        service().procesarPendientes();
+
+        assertThat(trabajo.getEstado()).isEqualTo(EstadoReciboPendiente.COMPLETADO);
+        assertThat(trabajo.getIntentos()).isOne();
+        assertThat(trabajo.getProcessedAt()).isEqualTo(NOW);
+        assertThat(recibo.getStorageKey()).isEqualTo("recibo_7.pdf");
+        assertThat(recibo.getGeneradoAt()).isEqualTo(NOW);
+        assertThat(recibo.getEnviadoAt()).isEqualTo(NOW);
+        assertThat(Files.readAllBytes(receiptsPath.resolve("recibo_7.pdf"))).isEqualTo(bytes);
+        verify(pdf, times(1)).generarReciboPdf(pago);
+        verify(email, times(1)).sendEmailWithAttachmentAndInlineImage(
+                any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void reintentaConLimiteYMarcaFalloPermanente() throws Exception {
+        Pago pago = pago(null);
+        Recibo recibo = recibo(pago);
+        ReciboPendiente reintentable = trabajo(pago, 0);
+        ReciboPendiente finalizado = trabajo(pago, 4);
+        when(pendientes.findClaimableForUpdate(any(Instant.class), eq(10)))
+                .thenReturn(List.of(reintentable))
+                .thenReturn(List.of(finalizado));
+        when(pendientes.findByIdAndClaimToken(eq(1L), any(UUID.class)))
+                .thenAnswer(invocation -> {
+                    UUID token = invocation.getArgument(1);
+                    if (token.equals(reintentable.getClaimToken())) return Optional.of(reintentable);
+                    if (token.equals(finalizado.getClaimToken())) return Optional.of(finalizado);
+                    return Optional.empty();
+                });
+        when(recibos.findByPagoId(7L)).thenReturn(Optional.of(recibo));
+        when(pdf.generarReciboPdf(pago)).thenThrow(new IllegalStateException("detalle que no se persiste"));
+
+        ReciboStorageService service = service();
+        service.procesarPendientes();
+        assertThat(reintentable.getEstado()).isEqualTo(EstadoReciboPendiente.PENDIENTE);
+        assertThat(reintentable.getNextAttemptAt()).isEqualTo(NOW.plusSeconds(300));
+        assertThat(reintentable.getUltimoError()).isEqualTo("IllegalStateException");
+
+        service.procesarPendientes();
+        assertThat(finalizado.getEstado()).isEqualTo(EstadoReciboPendiente.ERROR);
+        assertThat(finalizado.getIntentos()).isEqualTo(5);
+        assertThat(finalizado.getProcessedAt()).isEqualTo(NOW);
+        verify(email, never()).sendEmailWithAttachmentAndInlineImage(
+                any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void recuperaLeaseYNoRepiteDocumentoNiEmailYaConfirmados() throws Exception {
+        Pago pago = pago("alumno@example.test");
+        Recibo recibo = recibo(pago);
+        recibo.setStorageKey("recibo_7.pdf");
+        recibo.setGeneradoAt(NOW.minusSeconds(60));
+        recibo.setEnviadoAt(NOW.minusSeconds(30));
+        Files.write(receiptsPath.resolve("recibo_7.pdf"), "existente".getBytes());
+        ReciboPendiente trabajo = trabajo(pago, 1);
+        trabajo.setEstado(EstadoReciboPendiente.PROCESANDO);
+        trabajo.setClaimToken(UUID.randomUUID());
+        trabajo.setClaimedAt(NOW.minusSeconds(600));
+        trabajo.setLeaseUntil(NOW.minusSeconds(300));
+        when(pendientes.findClaimableForUpdate(any(Instant.class), eq(10))).thenReturn(List.of(trabajo));
+        when(pendientes.findByIdAndClaimToken(eq(1L), any(UUID.class)))
+                .thenAnswer(invocation -> Optional.of(trabajo));
+        when(recibos.findByPagoId(7L)).thenReturn(Optional.of(recibo));
+
+        service().procesarPendientes();
+
+        assertThat(trabajo.getEstado()).isEqualTo(EstadoReciboPendiente.COMPLETADO);
+        assertThat(trabajo.getIntentos()).isEqualTo(2);
+        assertThat(trabajo.getClaimToken()).isNull();
+        assertThat(trabajo.getLeaseUntil()).isNull();
+        verify(pdf, never()).generarReciboPdf(any());
+        verify(email, never()).sendEmailWithAttachmentAndInlineImage(
+                any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    private ReciboStorageService service() {
+        return new ReciboStorageService(pdf, email,
+                new AppProperties(ZoneOffset.UTC, receiptsPath, List.of("https://example.test")),
+                pendientes, recibos, aplicaciones, Clock.fixed(NOW, ZoneOffset.UTC), transactionManager);
+    }
+
+    private Pago pago(String email) {
+        Alumno alumno = new Alumno();
+        alumno.setEmail(email);
+        Pago pago = new Pago();
+        pago.setId(7L);
+        pago.setAlumno(alumno);
+        return pago;
+    }
+
+    private Recibo recibo(Pago pago) {
+        Recibo recibo = new Recibo();
+        recibo.setPago(pago);
+        return recibo;
+    }
+
+    private ReciboPendiente trabajo(Pago pago, int intentos) {
+        ReciboPendiente trabajo = new ReciboPendiente();
+        trabajo.setId(1L);
+        trabajo.setPago(pago);
+        trabajo.setIntentos(intentos);
+        trabajo.setNextAttemptAt(NOW);
+        trabajo.setIdempotencyKey("recibo:7:GENERAR_Y_ENVIAR");
+        return trabajo;
+    }
+}

--- a/frontend/src/funcionalidades/alumnos/AlumnosPagina.test.tsx
+++ b/frontend/src/funcionalidades/alumnos/AlumnosPagina.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AlumnoResponse, Page } from "../../types/types";
@@ -45,13 +45,27 @@ describe("AlumnosPagina paginada", () => {
   it("no expone el ID interno como columna visible", async () => {
     renderPage();
 
-    expect(await screen.findByText("Ana Prueba")).toBeVisible();
+    const tabla = await screen.findByRole("table");
 
-    expect(screen.queryByRole("columnheader", { name: "ID" })).not.toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Alumno" })).toBeVisible();
-    expect(screen.getByRole("columnheader", { name: "Documento" })).toBeVisible();
-    expect(screen.getByRole("columnheader", { name: "Contacto" })).toBeVisible();
-    expect(screen.getByRole("columnheader", { name: "Estado" })).toBeVisible();
+    expect(
+      within(tabla).queryByRole("columnheader", { name: "ID" }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(tabla).getByRole("columnheader", { name: "Alumno" }),
+    ).toBeVisible();
+
+    expect(
+      within(tabla).getByRole("columnheader", { name: "Documento" }),
+    ).toBeVisible();
+
+    expect(
+      within(tabla).getByRole("columnheader", { name: "Contacto" }),
+    ).toBeVisible();
+
+    expect(
+      within(tabla).getByRole("columnheader", { name: "Estado" }),
+    ).toBeVisible();
   });
 
   it("invalida solamente el recurso alumnos al dar de baja", async () => {

--- a/frontend/src/funcionalidades/pagos/PagosPagina.test.tsx
+++ b/frontend/src/funcionalidades/pagos/PagosPagina.test.tsx
@@ -69,7 +69,7 @@ describe("PagosPagina", () => {
     });
 
     expect(screen.getAllByText("Ana Prueba").length).toBeGreaterThan(0);
-    expect(await screen.findByText("$ 100.50")).toBeVisible();
+    expect(await screen.findByRole("cell", { name: "$ 100,50" })).toBeVisible();
     expect(screen.getByText("REGISTRADO")).toBeVisible();
   });
 
@@ -85,7 +85,7 @@ describe("PagosPagina", () => {
     });
 
     expect(await screen.findByText("Ana Prueba")).toBeVisible();
-    expect(await screen.findByText("$ 100.50")).toBeVisible();
+    expect(await screen.findByRole("cell", { name: "$ 100,50" })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Cambios

- Corrige expectativas de formato ARS en `PagosPagina.test.tsx`.
- Acota el test responsive de alumnos a la tabla desktop mediante `within`.
- Versiona la cobertura local de `ReciboStorageService`.
- Actualiza `checkout`, `setup-java` y `setup-node` a acciones con runtime Node 24.

## Causa

La restauración de los servicios PDF permitió que CI avanzara hasta Vitest. Los tres fallos restantes pertenecían al baseline conocido:

- dos expectativas `$ 100.50` frente al formato correcto `$ 100,50`;
- una query global ambigua por las representaciones desktop/mobile simultáneas de `Tabla`.

## Validación local

- Tests frontend focalizados: 2 archivos, 5 tests, PASS.
- Frontend oficial: lint PASS; 16 archivos y 39 tests PASS; TypeScript/Vite build PASS.
- Backend focalizado: 7 tests, 0 failures, 0 errors, 0 skipped, BUILD SUCCESS.
- Backend oficial: 116 tests, 0 failures, 0 errors, 0 skipped; Testcontainers/PostgreSQL/Flyway PASS; BUILD SUCCESS.
- Validador `All`: PASS.
- Compose local y producción con variables dummy: PASS.
- Imágenes backend y frontend: PASS.
- Smoke local aislado: FAIL; `POST /salones` devolvió 403 en lugar de 201 (8 pasos aprobados, 1 fallo). La limpieza del proyecto Docker aislado pasó.

## CI remota

Run: https://github.com/JerePrograma/Gestudio/actions/runs/29335324093

- `validate`: PASS (2m14s).
- `build-images`: PASS (2m19s).
- `smoke`: FAIL (3m2s) por el mismo `POST /salones` 403 (8 pasos aprobados, 1 fallo).
- GitGuardian: PASS.

## Riesgos residuales

- El smoke asume acceso operativo del usuario bootstrap, pero la migración RBAC vigente no asigna permisos al rol `SUPERADMIN`; debe resolverse el contrato de permisos o el aprovisionamiento del smoke en un cambio separado y explícito.
- `PagosPagina` muestra `pago.id` como `ID`; el backend y el esquema prueban que es una PK técnica, por lo que queda como deuda UX a ocultar.
- La documentación de release conserva un SHA base anterior y debe reconciliarse con el estado actual.
- Producción continúa en NO-GO hasta que un mismo SHA tenga verdes `validate`, `build-images`, `smoke` y los gates de release restantes.