### PR TITLE
Harden demo seed validation

### DIFF
--- a/docs/testing/demo-seed.md
+++ b/docs/testing/demo-seed.md
@@ -1,0 +1,942 @@
+# Seed integral de demostración de Gestudio
+
+## Estado del documento
+
+| Campo | Valor |
+|---|---|
+| Repositorio | `JerePrograma/Gestudio` |
+| Rama auditada | `main` |
+| HEAD auditado | `6443dbd735befbc0f9d05e78c03ef975bdd5156d` |
+| Fecha de auditoría | 2026-07-15 |
+| Seed manual | `scripts/gestudio_demo_seed_full.sql` |
+| Validador integral | `scripts/validate-demo-seed.ps1` |
+| Última versión Flyway auditada | `6` |
+| Migración productiva más reciente auditada | `V6__rbac_permission_catalog_and_base_roles.sql` |
+| Estado | Seed reconstruido y validación automatizada disponible |
+
+Este documento describe el mecanismo soportado para construir y validar un dataset comercial ficticio de Gestudio sobre una base PostgreSQL descartable.
+
+La migración `V6__rbac_permission_catalog_and_base_roles.sql` **no es un seed de demostración**. Es una migración productiva forward-only que define el catálogo RBAC y las matrices de los roles base. El seed manual exige que V6 haya sido aplicada correctamente, pero no la sustituye, no la copia y no modifica sus datos.
+
+---
+
+## 1. Propósito
+
+El seed crea una academia ficticia suficientemente completa para demostrar:
+
+- usuarios, roles y permisos;
+- alumnos activos e inactivos;
+- profesores, salones, disciplinas y horarios;
+- inscripciones activas, inactivas y finalizadas;
+- tarifas y condiciones económicas con vigencia;
+- mensualidades y matrículas;
+- cargos pendientes, parciales, pagados y anulados;
+- pagos simples, pagos distribuidos y anulaciones;
+- crédito generado, consumido, ajustado y revertido;
+- caja, egresos y reversos;
+- stock, ventas y reversión de ventas;
+- asistencias mensuales y diarias;
+- recibos y outbox de recibos;
+- reportes y permisos diferenciados por rol.
+
+La identidad narrativa utilizada es **Academia Movimiento Sur**. El esquema actual no posee una entidad `institucion`, por lo que ese nombre sólo aparece en descripciones y datos ficticios; no se crea una tabla nueva.
+
+---
+
+## 2. Separación obligatoria entre Flyway y datos demo
+
+### Flyway productivo
+
+Ubicación:
+
+```text
+backend/src/main/resources/db/migration
+```
+
+Responsabilidades:
+
+- crear y evolucionar el esquema;
+- realizar backfills productivos necesarios;
+- definir catálogos obligatorios;
+- definir el RBAC productivo;
+- conservar un historial forward-only.
+
+### Seed manual
+
+Ubicación:
+
+```text
+scripts/gestudio_demo_seed_full.sql
+```
+
+Responsabilidades:
+
+- cargar datos sintéticos de demostración;
+- reutilizar roles y permisos existentes;
+- validar integridad del dataset;
+- poder reejecutarse de forma controlada;
+- permanecer fuera del classpath de migraciones.
+
+El archivo manual:
+
+- no tiene prefijo `V`;
+- no debe renombrarse como migración;
+- no debe copiarse a `db/migration`;
+- no crea ni altera tablas;
+- no inserta, actualiza o elimina roles;
+- no inserta, actualiza o elimina permisos;
+- no modifica `rol_permisos`;
+- no activa el rol `PROFESOR`;
+- no contiene contraseñas en texto plano;
+- no debe ejecutarse en producción.
+
+---
+
+## 3. Prerrequisitos
+
+### Herramientas
+
+- Windows PowerShell 5.1 o PowerShell 7.
+- Git 2.x.
+- JDK 21 completo, con `java` y `javac`.
+- Docker Desktop con Engine iniciado.
+- Docker Compose v2.
+- Maven Wrapper versionado en el backend.
+
+El flujo automatizado no necesita Maven, PostgreSQL ni `psql` instalados globalmente. Usa Maven Wrapper, el contenedor PostgreSQL del proyecto y el cliente `psql` incluido en ese contenedor.
+
+### Estado del repositorio
+
+Antes de ejecutar:
+
+```powershell
+Set-Location C:\laburo\Gestudio
+
+git status --short --branch
+git branch --show-current
+git rev-parse HEAD
+git diff --exit-code
+git diff --cached --exit-code
+```
+
+La guía fue preparada contra:
+
+```text
+6443dbd735befbc0f9d05e78c03ef975bdd5156d
+```
+
+Si el HEAD es posterior, debe verificarse que:
+
+- `scripts/gestudio_demo_seed_full.sql` siga siendo compatible;
+- la última migración productiva continúe incluyendo V6;
+- no exista una migración Flyway de demostración;
+- las entidades y endpoints utilizados por el validador no hayan cambiado.
+
+### Docker
+
+Comprobar:
+
+```powershell
+docker info
+docker compose version
+```
+
+### Java
+
+Comprobar:
+
+```powershell
+java -version
+javac -version
+```
+
+Ambos deben resolver un JDK 21. El validador también busca instalaciones conocidas de JDK 21 y configura `JAVA_HOME` sólo dentro de su proceso.
+
+---
+
+## 4. Ejecución recomendada
+
+Desde la raíz del repositorio:
+
+### Windows PowerShell 5.1
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-demo-seed.ps1
+```
+
+### PowerShell 7
+
+```powershell
+pwsh -NoProfile -File .\scripts\validate-demo-seed.ps1
+```
+
+El script:
+
+1. valida su propia sintaxis;
+2. valida estáticamente el contrato del seed;
+3. compila el backend;
+4. crea un proyecto Compose aislado;
+5. asigna puertos aleatorios;
+6. crea PostgreSQL con credenciales aleatorias;
+7. inicia el backend real;
+8. deja que Flyway aplique las migraciones;
+9. exige V6 exitosa y ninguna migración demo;
+10. ejecuta Hibernate con `ddl-auto=validate`;
+11. genera cinco passwords aleatorias en memoria;
+12. genera cinco hashes BCrypt con el codificador real del backend;
+13. aplica el seed;
+14. valida conteos, RBAC e integridad financiera;
+15. arranca el backend sobre el dataset;
+16. prueba login, perfiles, endpoints y denegaciones;
+17. detiene el backend;
+18. aplica el seed por segunda vez;
+19. compara conteos, IDs, hashes y saldos;
+20. reinicia el backend y repite el login;
+21. elimina temporales, contenedores, red y volúmenes.
+
+### Reutilizar un JAR existente
+
+Sólo cuando ya exista un JAR actualizado en `backend/target`:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\scripts\validate-demo-seed.ps1 `
+  -SkipBackendBuild
+```
+
+El script falla si se usa `-SkipBackendBuild` y no encuentra un JAR utilizable.
+
+### Mostrar solicitudes HTTP
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\scripts\validate-demo-seed.ps1 `
+  -VerboseHttp
+```
+
+Este modo muestra método, ruta y código HTTP. Los secretos continúan redactados.
+
+### Combinación
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass `
+  -File .\scripts\validate-demo-seed.ps1 `
+  -SkipBackendBuild `
+  -VerboseHttp
+```
+
+---
+
+## 5. Aislamiento y limpieza del validador
+
+Cada ejecución crea un nombre de proyecto semejante a:
+
+```text
+gestudio-demo-seed-<PID>-<sufijo aleatorio>
+```
+
+También genera:
+
+- base PostgreSQL con nombre aleatorio;
+- usuario PostgreSQL aleatorio;
+- password PostgreSQL aleatoria;
+- secreto JWT aleatorio;
+- puerto PostgreSQL aleatorio;
+- puerto backend aleatorio;
+- directorio temporal aislado;
+- directorio temporal de recibos.
+
+El bloque `finally` intenta siempre:
+
+- detener el backend Java;
+- ejecutar `docker compose down --volumes --remove-orphans` sobre el proyecto aislado;
+- eliminar contenedores residuales con las etiquetas del proyecto;
+- eliminar la red aislada;
+- eliminar los volúmenes aislados;
+- eliminar el directorio temporal;
+- restaurar las variables de entorno del proceso.
+
+El script no usa la base local por defecto ni elimina volúmenes de otros proyectos Compose.
+
+Ante una interrupción abrupta del proceso, buscar recursos residuales antes de eliminarlos:
+
+```powershell
+docker ps -a --filter "name=gestudio-demo-seed-"
+docker volume ls --filter "name=gestudio-demo-seed-"
+docker network ls --filter "name=gestudio-demo-seed-"
+```
+
+Eliminar únicamente el proyecto aislado exacto que se haya identificado:
+
+```powershell
+docker compose -p <nombre-exacto-del-proyecto> down --volumes --remove-orphans
+```
+
+No ejecutar `docker volume prune` ni comandos globales de limpieza como sustituto.
+
+---
+
+## 6. Credenciales demo
+
+### Usuarios creados
+
+| Usuario | Rol efectivo | Propósito |
+|---|---|---|
+| `demo-superadmin` | Rol técnico completo detectado desde el catálogo productivo | Recuperación y validaciones técnicas |
+| `demo-direccion` | `DIRECCION` | Gestión de dirección |
+| `demo-administrador` | `ADMINISTRADOR` | Compatibilidad con el rol legacy |
+| `demo-secretaria` | `SECRETARIA` | Administración académica y cobros |
+| `demo-caja` | `CAJA` | Cobros y consultas operativas |
+
+No se crea un usuario con rol `PROFESOR`.
+
+### Generación segura
+
+El validador genera una password distinta para cada usuario mediante un generador criptográfico.
+
+Las passwords:
+
+- sólo existen en memoria;
+- no se imprimen;
+- no se guardan en `.env`;
+- no se escriben en el SQL;
+- no se guardan en los logs;
+- se eliminan de las estructuras en memoria al finalizar.
+
+Los hashes:
+
+- son BCrypt;
+- usan el `BCryptPasswordEncoder` del backend;
+- usan el strength configurado para la aplicación;
+- se envían al seed como variables `psql`;
+- se redactan en cualquier diagnóstico.
+
+El validador comprueba al finalizar que passwords, hashes, tokens y secretos no hayan quedado en archivos temporales.
+
+### Uso humano de una demo persistente
+
+El validador integral es un gate automatizado y destruye su entorno al terminar. No está diseñado para dejar una instancia comercial persistente ni para revelar las passwords generadas.
+
+Para preparar una demo persistente:
+
+1. crear una base PostgreSQL exclusivamente descartable;
+2. elegir cinco passwords aleatorias y almacenarlas en un gestor de secretos;
+3. generar sus hashes con el mismo `BCryptPasswordEncoder` del backend;
+4. conservar las passwords sólo en el gestor de secretos;
+5. pasar únicamente los hashes al seed;
+6. eliminar la base completa al terminar la demostración.
+
+No usar generadores BCrypt públicos en línea.
+
+---
+
+## 7. Aplicación manual avanzada
+
+La aplicación directa del SQL es secundaria. El método soportado para validar el resultado continúa siendo `validate-demo-seed.ps1`.
+
+### Variables obligatorias
+
+```text
+demo_anchor_date
+demo_superadmin_password_hash
+demo_direccion_password_hash
+demo_administrador_password_hash
+demo_secretaria_password_hash
+demo_caja_password_hash
+```
+
+`demo_anchor_date` debe tener formato:
+
+```text
+YYYY-MM-DD
+```
+
+Ejemplo de estructura del comando, usando valores ya generados de forma segura:
+
+```powershell
+psql "host=127.0.0.1 port=<puerto> dbname=<base-demo> user=<usuario-demo>" `
+  -v ON_ERROR_STOP=1 `
+  -v "demo_anchor_date=<YYYY-MM-DD>" `
+  -v "demo_superadmin_password_hash=<bcrypt>" `
+  -v "demo_direccion_password_hash=<bcrypt>" `
+  -v "demo_administrador_password_hash=<bcrypt>" `
+  -v "demo_secretaria_password_hash=<bcrypt>" `
+  -v "demo_caja_password_hash=<bcrypt>" `
+  -f .\scripts\gestudio_demo_seed_full.sql
+```
+
+El comando recibe hashes, nunca passwords en texto plano.
+
+### Condiciones previas obligatorias
+
+La base debe:
+
+- ser descartable;
+- tener todas las migraciones productivas aplicadas;
+- incluir `V6__rbac_permission_catalog_and_base_roles.sql` con `success=true`;
+- no contener migraciones Flyway demo;
+- no tener migraciones fallidas;
+- conservar 32 permisos activos de sistema;
+- conservar las matrices productivas exactas;
+- conservar `PROFESOR` inactivo, de sistema, no editable y sin permisos.
+
+### Transacción
+
+El seed usa:
+
+```sql
+BEGIN;
+...
+COMMIT;
+```
+
+También usa:
+
+```text
+\set ON_ERROR_STOP on
+```
+
+Una validación fallida aborta la ejecución y evita un commit parcial.
+
+---
+
+## 8. Fecha ancla y períodos relativos
+
+La fecha ancla se calcula en:
+
+```text
+America/Argentina/Buenos_Aires
+```
+
+A partir de ella se construyen:
+
+- período actual;
+- período anterior;
+- segundo período anterior;
+- vencimientos;
+- fechas de asistencia;
+- edades y cumpleaños ficticios;
+- fechas de pagos, ventas, egresos y reversos.
+
+Esto evita que el dataset quede obsoleto por tener fechas fijas antiguas.
+
+### Regla de reejecución
+
+Para una reejecución determinista deben reutilizarse:
+
+- la misma `demo_anchor_date`;
+- los mismos cinco hashes BCrypt.
+
+El seed rechaza una fecha ancla diferente cuando ya existe el namespace demo. No desplaza datos históricos ni acumula períodos silenciosamente.
+
+Usar hashes distintos actualiza credenciales y deja de ser una comparación byte a byte del mismo dataset. El validador conserva los hashes entre la primera y segunda aplicación.
+
+---
+
+## 9. Namespace demo
+
+Los datos se reconocen mediante claves naturales reservadas:
+
+| Tipo | Convención |
+|---|---|
+| Usuarios | `demo-*` |
+| Correos | `*@gestudio-demo.invalid` |
+| Documentos | `DEMO-DNI-*` |
+| Catálogos visibles | `DEMO · *` |
+| Códigos de stock | `DEMO-STOCK-*` |
+| Idempotencia | `demo-seed:v1:*` |
+| Motivos internos | `[DEMO:*]` |
+| Storage keys | `demo/recibos/*` |
+
+El seed no utiliza IDs rígidos como identidad del dataset y no mueve secuencias a rangos artificiales.
+
+---
+
+## 10. Escenarios incluidos
+
+### Académicos
+
+- alumnos menores y adultos;
+- alumnos activos e inactivos;
+- alumnos sin inscripción;
+- inscripciones activas, inactivas y finalizadas;
+- alumnos en una y varias disciplinas;
+- profesores activos e inactivos;
+- disciplinas con uno y dos días semanales;
+- tarifas históricas y actuales;
+- costo particular;
+- descuentos porcentuales y fijos;
+- historial de cambios en condiciones económicas;
+- mensualidades de varios períodos;
+- matrículas del año operativo;
+- planillas de asistencia por disciplina;
+- presentes y ausentes.
+
+### Financieros
+
+- cargo pendiente;
+- cargo vencido;
+- cargo parcialmente pagado;
+- cargo completamente pagado;
+- cargo anulado;
+- pago aplicado a un cargo;
+- pago distribuido entre varios cargos;
+- pago anulado con aplicaciones revertidas;
+- pago con excedente y generación de crédito;
+- consumo de crédito;
+- reversión de consumo;
+- ajuste de crédito;
+- ajuste de débito;
+- recargo vinculado a otro cargo;
+- egreso registrado;
+- egreso anulado;
+- ajustes manuales de caja;
+- conciliación de movimientos de caja.
+
+### Stock
+
+- producto con control de stock;
+- producto sin control de stock;
+- ingreso de stock;
+- ajuste positivo;
+- ajuste negativo;
+- venta pendiente;
+- venta pagada;
+- venta anulada y revertida;
+- restauración del stock después de una reversión.
+
+### Seguridad
+
+- login de cinco roles;
+- usuario anónimo rechazado con 401;
+- acceso permitido según rol;
+- acceso autenticado sin permiso rechazado con 403;
+- `PROFESOR` fuera de roles asignables;
+- catálogo RBAC sin modificaciones;
+- matrices RBAC sin modificaciones.
+
+---
+
+## 11. Tablas pobladas directamente por el seed
+
+| Tabla | Filas demo esperadas |
+|---|---:|
+| `usuarios` | 5 |
+| `usuario_roles` | 5 |
+| `salones` | 3 |
+| `profesores` | 6 |
+| `observaciones_profesores` | 6 |
+| `bonificaciones` | 4 |
+| `recargos` | 3 |
+| `metodo_pagos` | 4 |
+| `sub_conceptos` | 4 |
+| `conceptos` | 8 |
+| `stocks` | 6 |
+| `disciplinas` | 6 |
+| `disciplina_horarios` | 11 |
+| `alumnos` | 28 |
+| `inscripciones` | 34 |
+| `disciplina_tarifas` | 12 |
+| `inscripcion_condiciones_economicas` | 40 |
+| `mensualidades` | 70 |
+| `matriculas` | 26 |
+| `asistencias_mensuales` | 6 |
+| `asistencias_alumno_mensual` | 18 |
+| `asistencias_diarias` | 54 |
+| `ventas_stock` | 6 |
+| `cargos` | 115 |
+| `cargo_liquidaciones` | 115 |
+| `pagos` | 48 |
+| `aplicaciones_pago` | 82 |
+| `egresos` | 7 |
+| `movimientos_caja` | 61 |
+| `movimientos_credito` | 11 |
+| `movimientos_stock` | 14 |
+| `recibos` | 48 |
+| `recibos_pendientes` | 48 |
+| **Total gestionado directamente** | **914** |
+
+Los conteos se validan dentro de la misma transacción del seed.
+
+---
+
+## 12. Tablas consultadas pero no modificadas
+
+El seed consulta las siguientes fuentes de verdad productivas:
+
+```text
+flyway_schema_history
+roles
+permisos
+rol_permisos
+```
+
+Las utiliza para:
+
+- verificar que el esquema es compatible;
+- encontrar los roles existentes;
+- resolver el rol técnico completo sin duplicarlo;
+- comprobar el catálogo de 32 permisos;
+- capturar y comparar las matrices RBAC.
+
+El seed no ejecuta `INSERT`, `UPDATE` ni `DELETE` sobre esas tablas.
+
+---
+
+## 13. Tablas derivadas no pobladas por el seed
+
+El seed captura el conteo inicial y exige no modificar:
+
+```text
+refresh_sessions
+bootstrap_ejecuciones
+auditoria_eventos
+cargo_eventos
+notificaciones
+```
+
+Motivos:
+
+- `refresh_sessions` debe surgir de autenticación real;
+- `bootstrap_ejecuciones` pertenece al bootstrap productivo;
+- `auditoria_eventos` es append-only y debe reflejar operaciones reales;
+- `cargo_eventos` es append-only y debe reflejar servicios reales;
+- `notificaciones` debe surgir del servicio de notificaciones.
+
+Durante la fase HTTP del validador sí pueden aparecer sesiones o auditorías generadas legítimamente por la aplicación. Eso ocurre después de validar que el SQL por sí solo no falsificó datos derivados.
+
+---
+
+## 14. Conteos y agregados esperados
+
+La validación ejecutada durante la reconstrucción produjo:
+
+```text
+Usuarios demo:                    5
+Alumnos demo:                    28
+Inscripciones demo:              34
+Mensualidades demo:              70
+Matrículas demo:                 26
+Cargos demo:                    115
+Pagos demo:                      48
+Aplicaciones demo:               82
+Movimientos de caja:             61
+Movimientos de crédito:          11
+Movimientos de stock:            14
+Recibos:                         48
+Outbox de recibos:               48
+```
+
+Agregados financieros de referencia:
+
+```text
+Pagos registrados:            $1.956.700,00
+Aplicaciones activas:         $1.938.700,00
+Crédito activo de pagos:         $18.000,00
+Crédito neto global:              $21.000,00
+```
+
+Conciliación principal:
+
+```text
+$1.938.700,00 + $18.000,00 = $1.956.700,00
+```
+
+Los valores son deterministas para la versión actual del seed y la misma fecha ancla.
+
+---
+
+## 15. Validaciones internas del SQL
+
+Antes del `COMMIT`, el seed verifica:
+
+- existencia de todas las tablas requeridas;
+- V6 aplicada correctamente;
+- ausencia de migraciones demo;
+- ausencia de migraciones fallidas;
+- presencia y actividad de roles operativos;
+- estado exacto del rol `PROFESOR`;
+- 32 permisos activos de sistema;
+- conteos exactos por rol;
+- protección de usuarios no demo;
+- cardinalidad exacta del dataset;
+- ausencia de FK huérfanas;
+- origen exclusivo de cada cargo;
+- una liquidación por cargo;
+- pagos conciliados con aplicaciones y crédito;
+- aplicaciones no superiores al pago;
+- aplicaciones no superiores al cargo;
+- saldos de cargos no negativos;
+- estados de cargos coherentes;
+- saldo de crédito no negativo;
+- stock no negativo;
+- stock materializado coherente con su libro;
+- ventas con cargo y movimiento;
+- ventas anuladas con reverso;
+- recibos únicos;
+- outbox única;
+- claves de idempotencia únicas;
+- un único reverso por operación original;
+- catálogo RBAC sin cambios;
+- matrices RBAC sin cambios;
+- tablas derivadas sin cambios.
+
+Cualquier incumplimiento provoca una excepción y evita el commit.
+
+---
+
+## 16. Validaciones del script PowerShell
+
+Además de las validaciones SQL, `validate-demo-seed.ps1` comprueba:
+
+- parser nativo de PowerShell sin errores;
+- estructura esperada del repositorio;
+- ausencia de operaciones prohibidas en el seed;
+- ausencia de credenciales conocidas;
+- Docker y Compose disponibles;
+- JDK 21 disponible;
+- compilación del backend;
+- PostgreSQL aislado healthy;
+- backend iniciado con Flyway y Hibernate validate;
+- `flyway_schema_history` correcto;
+- checksums presentes;
+- V6 productiva presente;
+- ninguna migración demo;
+- login de los cinco usuarios;
+- 32 permisos en el perfil técnico;
+- roles asignables correctos;
+- endpoints representativos;
+- respuestas 401, 403, 200 y 400 esperadas;
+- integridad financiera por SQL;
+- idempotencia de una segunda ejecución;
+- IDs estables;
+- hashes de contenido estables;
+- RBAC estable;
+- login posterior a la reejecución;
+- ausencia de secretos en temporales;
+- limpieza de infraestructura.
+
+El proceso devuelve un exit code distinto de cero ante cualquier fallo.
+
+---
+
+## 17. Reejecución e idempotencia
+
+La segunda ejecución debe conservar:
+
+- los mismos IDs;
+- los mismos conteos;
+- los mismos importes;
+- los mismos estados;
+- las mismas asociaciones;
+- las mismas claves de idempotencia;
+- los mismos saldos;
+- las mismas matrices RBAC.
+
+El validador toma un snapshot después de la primera ejecución y otro después de la segunda. Compara tanto conteos como huellas MD5 ordenadas de los datos demo.
+
+Una segunda ejecución con otra fecha ancla no es un caso soportado sobre la misma base. Debe crearse otra base descartable.
+
+---
+
+## 18. Limpieza de una aplicación manual
+
+La estrategia soportada es eliminar la base descartable completa.
+
+No intentar limpiar selectivamente el dataset cuando la aplicación ya haya generado:
+
+- auditorías;
+- eventos de cargo;
+- sesiones;
+- recibos físicos;
+- notificaciones;
+- otras referencias históricas.
+
+Esas tablas son históricas o append-only y una limpieza selectiva puede destruir trazabilidad.
+
+En un proyecto Compose creado exclusivamente para la demo:
+
+```powershell
+docker compose -p <proyecto-demo-exacto> down --volumes --remove-orphans
+```
+
+Antes de ejecutar el comando, confirmar el nombre exacto del proyecto y que no corresponde al entorno habitual de desarrollo.
+
+No usar:
+
+```text
+TRUNCATE
+DROP SCHEMA public
+docker volume prune
+session_replication_role
+DISABLE TRIGGER
+DELETE sin filtros
+```
+
+---
+
+## 19. Limitaciones conocidas
+
+### Estado de asistencia `JUSTIFICADO`
+
+La migración V1 define:
+
+```sql
+estado VARCHAR(10)
+```
+
+pero el `CHECK` admite `JUSTIFICADO`, que ocupa 11 caracteres. PostgreSQL rechaza el valor antes de evaluar el constraint.
+
+El seed actual utiliza únicamente:
+
+```text
+PRESENTE
+AUSENTE
+```
+
+hasta que una migración productiva posterior amplíe la columna. No modificar V1 retroactivamente.
+
+### Recibos físicos
+
+El seed crea metadatos de `recibos` y `recibos_pendientes`, pero no fabrica archivos PDF. Algunas filas contienen una `storage_key` ficticia bajo `demo/recibos/` para representar estados históricos.
+
+El endpoint de descarga puede devolver 404 si no existe el archivo físico, lo cual es esperado para esos registros sintéticos.
+
+### Eventos y auditoría
+
+El SQL no crea `cargo_eventos` ni `auditoria_eventos`. Las pantallas que dependan exclusivamente de eventos posteriores pueden mostrar sólo aquello generado durante operaciones reales de la aplicación.
+
+### Profesores sin usuario
+
+Los seis profesores demo tienen `usuario_id = NULL`. El rol `PROFESOR` permanece deshabilitado hasta que exista ownership seguro en backend.
+
+### Dataset descartable
+
+El seed no es un instalador, una migración ni un mecanismo de restauración. No debe utilizarse para reparar datos productivos.
+
+---
+
+## 20. Advertencia de producción
+
+> **PROHIBIDO EJECUTAR ESTE SEED EN PRODUCCIÓN.**
+>
+> El archivo crea identidades ficticias, pagos, cargos, movimientos de caja, crédito, stock y recibos. Aunque utiliza namespace reservado y protege RBAC, está diseñado únicamente para bases locales o efímeras de demostración.
+
+No ejecutar contra:
+
+- una base productiva;
+- una copia con datos personales reales;
+- un entorno compartido por usuarios;
+- un entorno cuya eliminación completa no esté autorizada;
+- una base que se use como respaldo o staging persistente.
+
+La precondición del seed no puede determinar por sí sola si una base es comercialmente productiva. La responsabilidad de elegir una base descartable pertenece al operador.
+
+---
+
+## 21. Solución de problemas
+
+### Docker no está disponible
+
+```text
+Docker no está disponible en PATH
+```
+
+Acciones:
+
+1. iniciar Docker Desktop;
+2. esperar a que el Engine esté operativo;
+3. ejecutar `docker info`;
+4. reintentar.
+
+### No se encuentra JDK 21
+
+Comprobar:
+
+```powershell
+$env:JAVA_HOME
+java -version
+javac -version
+```
+
+`JAVA_HOME` debe apuntar a un JDK, no a un JRE.
+
+### `-SkipBackendBuild` falla
+
+Ejecutar primero sin el switch o generar el JAR:
+
+```powershell
+Set-Location .\backend
+.\mvnw.cmd -DskipTests package
+Set-Location ..
+```
+
+### V6 no fue aplicada
+
+No ejecutar el seed directamente. Iniciar el backend con Flyway habilitado y revisar `flyway_schema_history`.
+
+Consulta de diagnóstico:
+
+```sql
+SELECT installed_rank, version, description, script, checksum, success
+FROM flyway_schema_history
+ORDER BY installed_rank;
+```
+
+### Se detectó una migración demo
+
+Retirar la migración de demostración del classpath y reconstruir una base desde cero. No editar manualmente `flyway_schema_history`.
+
+### La fecha ancla difiere
+
+Eliminar la base descartable y crear otra. No actualizar en masa fechas históricas.
+
+### La segunda ejecución cambia el snapshot
+
+Revisar:
+
+- que se reutilice la misma fecha ancla;
+- que se reutilicen los mismos hashes;
+- que no hayan corrido schedulers;
+- que no haya procesos externos modificando la base;
+- que el backend se haya detenido antes de la segunda ejecución.
+
+### Quedaron recursos Docker
+
+Listar recursos por nombre exacto y eliminar sólo el proyecto aislado. No usar limpiezas globales.
+
+---
+
+## 22. Criterios de aceptación
+
+La validación se considera exitosa cuando:
+
+- el script termina con exit code 0;
+- todas las etapas relevantes aparecen como `PASS`;
+- Flyway aplicó todas las migraciones productivas;
+- V6 está presente y exitosa;
+- no existe migración Flyway demo;
+- Hibernate inicia con `ddl-auto=validate`;
+- los cinco usuarios pueden iniciar sesión;
+- los perfiles reflejan los roles esperados;
+- las pruebas positivas y negativas de RBAC coinciden con V6;
+- los conteos del dataset son exactos;
+- no existen inconsistencias financieras;
+- la segunda ejecución produce un snapshot idéntico;
+- RBAC no cambia;
+- no quedan secretos en temporales;
+- no quedan contenedores, redes o volúmenes del proyecto aislado.
+
+---
+
+## 23. Archivos relacionados
+
+```text
+scripts/gestudio_demo_seed_full.sql
+scripts/validate-demo-seed.ps1
+docs/testing/demo-seed.md
+docs/codex/gestudio-release-hardening/12_AUDITORIA_SEED_DEMO.md
+backend/src/main/resources/db/migration/V6__rbac_permission_catalog_and_base_roles.sql
+```
+
+El informe de auditoría y evidencia final se mantiene separado de esta guía operativa.

--- a/scripts/gestudio_demo_seed_full.sql
+++ b/scripts/gestudio_demo_seed_full.sql
@@ -1,355 +1,483 @@
--- V6__demo_seed_complete.sql
--- Migración Flyway EXCLUSIVA para una base de demostración de Gestudio.
--- Autoridad de esquema: V1..V5 del branch main, commit 644e044b26438516ea093513ca5651ce72fb3fb3.
---
--- ADVERTENCIA:
---   * Incluye credenciales conocidas y datos ficticios.
---   * No debe habilitarse en producción.
---   * Ejecutar únicamente en una base nueva o dedicada a demostraciones.
---
--- Credenciales:
---   admin      / admin
---   secretaria / admin
---   profesor   / admin
---
--- Hash BCrypt compartido para la contraseña "admin":
--- $2a$10$20gyPVFS3kpF8j8KZ.c0zer5c1LUzVWJS7Uu9rdvQVFxJp8Oc1hBa
+-- ESTE ARCHIVO NO ES UNA MIGRACIÓN FLYWAY.
+-- Seed manual, sintético y descartable para validar Gestudio después de V1..V6.
+-- No ejecutar sobre una base que contenga datos que deban conservarse.
+
+\set ON_ERROR_STOP on
 
 BEGIN;
 
--- ============================================================
--- PRECONDICIÓN: esta V6 debe ejecutarse después de V1..V5
--- ============================================================
+SET LOCAL TIME ZONE 'America/Argentina/Buenos_Aires';
+
+CREATE TEMP TABLE _demo_config ON COMMIT DROP AS
+SELECT
+    :'demo_anchor_date'::date AS anchor_date,
+    date_trunc('month', :'demo_anchor_date'::date)::date AS month_0,
+    (date_trunc('month', :'demo_anchor_date'::date) - interval '1 month')::date AS month_1,
+    (date_trunc('month', :'demo_anchor_date'::date) - interval '2 months')::date AS month_2,
+    (:'demo_anchor_date'::date::timestamp + time '12:00') AT TIME ZONE 'America/Argentina/Buenos_Aires' AS anchor_ts;
 
 DO $$
+DECLARE
+    required_table text;
+    missing_tables text[] := ARRAY[]::text[];
+    full_role_count integer;
 BEGIN
-    IF to_regclass('public.usuario_roles') IS NULL
-       OR to_regclass('public.rol_permisos') IS NULL
-       OR to_regclass('public.permisos') IS NULL THEN
-        RAISE EXCEPTION
-            'V6 demo requiere que Flyway haya aplicado V1..V5 completamente';
+    IF (SELECT anchor_date FROM _demo_config) NOT BETWEEN DATE '2020-01-01' AND DATE '2099-12-31' THEN
+        RAISE EXCEPTION 'demo_anchor_date fuera del rango admitido';
+    END IF;
+
+    FOREACH required_table IN ARRAY ARRAY[
+        'flyway_schema_history', 'roles', 'usuarios', 'permisos', 'rol_permisos', 'usuario_roles',
+        'alumnos', 'salones', 'profesores', 'observaciones_profesores', 'disciplinas',
+        'disciplina_horarios', 'inscripciones', 'bonificaciones', 'recargos', 'metodo_pagos',
+        'sub_conceptos', 'conceptos', 'disciplina_tarifas', 'inscripcion_condiciones_economicas',
+        'mensualidades', 'matriculas', 'cargos', 'cargo_liquidaciones', 'pagos',
+        'aplicaciones_pago', 'egresos', 'movimientos_caja', 'movimientos_credito', 'stocks',
+        'ventas_stock', 'movimientos_stock', 'asistencias_mensuales',
+        'asistencias_alumno_mensual', 'asistencias_diarias', 'recibos', 'recibos_pendientes',
+        'refresh_sessions', 'bootstrap_ejecuciones', 'auditoria_eventos', 'cargo_eventos',
+        'notificaciones'
+    ] LOOP
+        IF to_regclass('public.' || required_table) IS NULL THEN
+            missing_tables := array_append(missing_tables, required_table);
+        END IF;
+    END LOOP;
+
+    IF cardinality(missing_tables) > 0 THEN
+        RAISE EXCEPTION 'Faltan tablas requeridas: %', array_to_string(missing_tables, ', ');
+    END IF;
+
+    IF (SELECT count(*) FROM public.flyway_schema_history WHERE success) <> 6
+       OR EXISTS (SELECT 1 FROM public.flyway_schema_history WHERE NOT success)
+       OR NOT EXISTS (
+            SELECT 1
+            FROM public.flyway_schema_history
+            WHERE version = '6'
+              AND success
+              AND script = 'V6__rbac_permission_catalog_and_base_roles.sql'
+       )
+       OR EXISTS (
+            SELECT 1
+            FROM public.flyway_schema_history
+            WHERE lower(script) LIKE '%demo%seed%'
+               OR lower(script) LIKE '%seed%demo%'
+       ) THEN
+        RAISE EXCEPTION 'El historial Flyway no coincide con V1..V6 productivas';
+    END IF;
+
+    IF (SELECT count(*) FROM public.permisos WHERE activo AND sistema) <> 32 THEN
+        RAISE EXCEPTION 'El catálogo productivo no contiene 32 permisos activos de sistema';
+    END IF;
+
+    SELECT count(*)
+    INTO full_role_count
+    FROM public.roles r
+    WHERE r.activo
+      AND r.sistema
+      AND NOT r.editable
+      AND (SELECT count(*) FROM public.rol_permisos rp WHERE rp.rol_id = r.id) =
+          (SELECT count(*) FROM public.permisos p WHERE p.activo AND p.sistema);
+
+    IF full_role_count <> 1 THEN
+        RAISE EXCEPTION 'No se pudo resolver un único rol técnico completo';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.roles r
+        WHERE r.codigo = 'DIRECCION' AND r.activo
+          AND (SELECT count(*) FROM public.rol_permisos rp WHERE rp.rol_id = r.id) = 31
+    ) OR NOT EXISTS (
+        SELECT 1 FROM public.roles r
+        WHERE r.codigo = 'ADMINISTRADOR' AND r.activo
+          AND (SELECT count(*) FROM public.rol_permisos rp WHERE rp.rol_id = r.id) = 31
+    ) OR NOT EXISTS (
+        SELECT 1 FROM public.roles r
+        WHERE r.codigo = 'SECRETARIA' AND r.activo
+          AND (SELECT count(*) FROM public.rol_permisos rp WHERE rp.rol_id = r.id) = 17
+    ) OR NOT EXISTS (
+        SELECT 1 FROM public.roles r
+        WHERE r.codigo = 'CAJA' AND r.activo
+          AND (SELECT count(*) FROM public.rol_permisos rp WHERE rp.rol_id = r.id) = 8
+    ) OR NOT EXISTS (
+        SELECT 1 FROM public.roles r
+        WHERE r.codigo = 'PROFESOR' AND NOT r.activo AND r.sistema AND NOT r.editable
+          AND NOT EXISTS (SELECT 1 FROM public.rol_permisos rp WHERE rp.rol_id = r.id)
+    ) THEN
+        RAISE EXCEPTION 'La matriz de roles base no coincide con el contrato productivo';
     END IF;
 END
 $$;
 
--- ============================================================
--- A. Catálogo RBAC demo autosuficiente
--- ============================================================
+CREATE TEMP TABLE _demo_guard ON COMMIT DROP AS
+SELECT
+    (SELECT count(*) FROM public.roles) AS roles_count,
+    (SELECT md5(COALESCE(string_agg(
+        r.id::text || '|' || r.codigo || '|' || r.activo::text || '|' || r.sistema::text || '|' || r.editable::text,
+        E'\n' ORDER BY r.id), '')) FROM public.roles r) AS roles_hash,
+    (SELECT count(*) FROM public.permisos) AS permissions_count,
+    (SELECT md5(COALESCE(string_agg(
+        p.id::text || '|' || p.codigo || '|' || p.activo::text || '|' || p.sistema::text || '|' || p.modulo || '|' || p.descripcion,
+        E'\n' ORDER BY p.id), '')) FROM public.permisos p) AS permissions_hash,
+    (SELECT count(*) FROM public.rol_permisos) AS matrix_count,
+    (SELECT md5(COALESCE(string_agg(
+        rp.rol_id::text || '|' || rp.permiso_id::text,
+        E'\n' ORDER BY rp.rol_id, rp.permiso_id), '')) FROM public.rol_permisos rp) AS matrix_hash,
+    (SELECT count(*) FROM public.usuarios u WHERE lower(u.nombre_usuario) NOT LIKE 'demo-%') AS other_users_count,
+    (SELECT md5(COALESCE(string_agg(to_jsonb(u)::text, E'\n' ORDER BY u.id), ''))
+        FROM public.usuarios u WHERE lower(u.nombre_usuario) NOT LIKE 'demo-%') AS other_users_hash,
+    (SELECT count(*) FROM public.refresh_sessions) AS refresh_count,
+    (SELECT count(*) FROM public.bootstrap_ejecuciones) AS bootstrap_count,
+    (SELECT count(*) FROM public.auditoria_eventos) AS audit_count,
+    (SELECT count(*) FROM public.cargo_eventos) AS charge_events_count,
+    (SELECT count(*) FROM public.notificaciones) AS notifications_count;
 
-INSERT INTO public.roles (
-    descripcion, activo, codigo, nombre,
-    descripcion_funcional, sistema, editable
-)
+DO $$
+DECLARE
+    expected_note text := '[DEMO:SEED_V1] anchor=' || (SELECT anchor_date::text FROM _demo_config);
+    namespace_exists boolean;
+BEGIN
+    SELECT EXISTS (SELECT 1 FROM public.usuarios WHERE lower(nombre_usuario) LIKE 'demo-%')
+        OR EXISTS (SELECT 1 FROM public.alumnos WHERE documento LIKE 'DEMO-DNI-%')
+        OR EXISTS (SELECT 1 FROM public.cargos WHERE idempotency_key LIKE 'demo-seed:v1:%')
+    INTO namespace_exists;
+
+    IF namespace_exists AND NOT EXISTS (
+        SELECT 1
+        FROM public.alumnos
+        WHERE documento = 'DEMO-DNI-A001'
+          AND otras_notas = expected_note
+    ) THEN
+        RAISE EXCEPTION 'El namespace demo ya existe con otra fecha ancla o está incompleto';
+    END IF;
+END
+$$;
+
+-- Usuarios demo. El rol técnico completo se resuelve por propiedades y matriz.
+CREATE TEMP TABLE _demo_users_desired (
+    username varchar(100) PRIMARY KEY,
+    password_hash varchar(100) NOT NULL,
+    role_id bigint NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _demo_users_desired (username, password_hash, role_id)
+SELECT 'demo-superadmin', :'demo_superadmin_password_hash', r.id
+FROM public.roles r
+WHERE r.activo
+  AND r.sistema
+  AND NOT r.editable
+  AND (SELECT count(*) FROM public.rol_permisos rp WHERE rp.rol_id = r.id) =
+      (SELECT count(*) FROM public.permisos p WHERE p.activo AND p.sistema)
+UNION ALL
+SELECT 'demo-direccion', :'demo_direccion_password_hash', r.id
+FROM public.roles r WHERE r.codigo = 'DIRECCION' AND r.activo
+UNION ALL
+SELECT 'demo-administrador', :'demo_administrador_password_hash', r.id
+FROM public.roles r WHERE r.codigo = 'ADMINISTRADOR' AND r.activo
+UNION ALL
+SELECT 'demo-secretaria', :'demo_secretaria_password_hash', r.id
+FROM public.roles r WHERE r.codigo = 'SECRETARIA' AND r.activo
+UNION ALL
+SELECT 'demo-caja', :'demo_caja_password_hash', r.id
+FROM public.roles r WHERE r.codigo = 'CAJA' AND r.activo;
+
+DO $$
+BEGIN
+    IF (SELECT count(*) FROM _demo_users_desired) <> 5
+       OR EXISTS (
+            SELECT 1 FROM _demo_users_desired
+            WHERE password_hash !~ '^[$]2[aby][$][0-9]{2}[$][./A-Za-z0-9]{53}$'
+       )
+       OR (SELECT count(DISTINCT password_hash) FROM _demo_users_desired) <> 5 THEN
+        RAISE EXCEPTION 'Las cinco identidades demo no tienen roles o hashes BCrypt efímeros válidos y distintos';
+    END IF;
+END
+$$;
+
+INSERT INTO public.usuarios (nombre_usuario, contrasena, rol_id, activo, auth_version, password_changed_at, version)
+SELECT username, password_hash, role_id, TRUE, 0, (SELECT anchor_ts FROM _demo_config), 0
+FROM _demo_users_desired
+ON CONFLICT (lower(nombre_usuario)) DO UPDATE
+SET contrasena = EXCLUDED.contrasena,
+    rol_id = EXCLUDED.rol_id,
+    activo = TRUE,
+    password_changed_at = EXCLUDED.password_changed_at;
+
+DELETE FROM public.usuario_roles ur
+USING public.usuarios u, _demo_users_desired d
+WHERE ur.usuario_id = u.id
+  AND lower(u.nombre_usuario) = d.username
+  AND ur.rol_id <> d.role_id;
+
+INSERT INTO public.usuario_roles (usuario_id, rol_id, asignado_at, asignado_por_usuario_id)
+SELECT u.id,
+       d.role_id,
+       (SELECT anchor_ts FROM _demo_config),
+       (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'demo-superadmin')
+FROM _demo_users_desired d
+JOIN public.usuarios u ON lower(u.nombre_usuario) = d.username
+ON CONFLICT (usuario_id, rol_id) DO UPDATE
+SET asignado_at = EXCLUDED.asignado_at,
+    asignado_por_usuario_id = EXCLUDED.asignado_por_usuario_id;
+
+-- Catálogos visibles.
+INSERT INTO public.salones (nombre, descripcion, activo)
 VALUES
-    ('SUPERADMIN', TRUE, 'SUPERADMIN', 'Superadministrador',
-     'Administración técnica completa de la plataforma', TRUE, FALSE),
-    ('ADMINISTRADOR', TRUE, 'ADMINISTRADOR', 'Dirección / Administración',
-     'Administración integral de la institución', TRUE, TRUE),
-    ('SECRETARIA', TRUE, 'SECRETARIA', 'Secretaría',
-     'Gestión cotidiana de alumnos, cobros, caja, inscripciones y stock', FALSE, TRUE),
-    ('PROFESOR', TRUE, 'PROFESOR', 'Profesor',
-     'Consulta operativa de sus clases, alumnos y asistencias', FALSE, TRUE)
-ON CONFLICT (codigo) DO UPDATE
+    ('DEMO · Sala Norte', 'Salón amplio con piso técnico.', TRUE),
+    ('DEMO · Sala Sur', 'Salón para grupos infantiles.', TRUE),
+    ('DEMO · Estudio Central', 'Espacio multipropósito de la demo.', TRUE)
+ON CONFLICT (nombre) DO UPDATE
 SET descripcion = EXCLUDED.descripcion,
-    activo = EXCLUDED.activo,
-    nombre = EXCLUDED.nombre,
-    descripcion_funcional = EXCLUDED.descripcion_funcional,
-    sistema = EXCLUDED.sistema,
-    editable = EXCLUDED.editable;
+    activo = EXCLUDED.activo;
 
-WITH seed(codigo, descripcion, modulo) AS (
-    VALUES
-        ('PERM_APP_ACCESO', 'Acceso general a la aplicación', 'APP'),
-        ('PERM_USUARIOS_ADMIN', 'Administrar usuarios', 'USUARIOS'),
-        ('PERM_ROLES_ADMIN', 'Administrar roles y permisos', 'ROLES'),
-        ('PERM_AUDITORIA_SEGURIDAD_LEER', 'Consultar auditoría de seguridad', 'AUDITORIA'),
-        ('PERM_MENSUALIDADES_GENERAR_MANUAL', 'Generar mensualidades manualmente', 'MENSUALIDADES'),
-        ('PERM_PAGOS_REGISTRAR', 'Registrar pagos', 'PAGOS'),
-        ('PERM_PAGOS_ANULAR', 'Anular pagos', 'PAGOS'),
-        ('PERM_EGRESOS_ADMIN', 'Administrar egresos', 'EGRESOS'),
-        ('PERM_STOCK_ADMIN', 'Administrar catálogo y movimientos de stock', 'STOCK'),
-        ('PERM_STOCK_VENDER', 'Registrar ventas de stock', 'STOCK'),
-        ('PERM_CREDITOS_ADMIN', 'Administrar créditos de alumnos', 'CREDITOS'),
-        ('PERM_CREDITOS_CONSUMIR', 'Aplicar créditos a cargos', 'CREDITOS'),
-        ('PERM_TARIFAS_ADMIN', 'Administrar tarifas por vigencia', 'TARIFAS'),
-        ('PERM_TARIFAS_HISTORICAS', 'Consultar historial de tarifas', 'TARIFAS'),
-        ('PERM_CONDICIONES_ECONOMICAS_ADMIN',
-         'Administrar condiciones económicas de inscripciones', 'CONDICIONES')
-)
-INSERT INTO public.permisos (codigo, descripcion, modulo, activo, sistema)
-SELECT codigo, descripcion, modulo, TRUE, TRUE
-FROM seed
-ON CONFLICT (codigo) DO UPDATE
-SET descripcion = EXCLUDED.descripcion,
-    modulo = EXCLUDED.modulo,
-    activo = TRUE,
-    sistema = TRUE;
+CREATE TEMP TABLE _demo_professors_desired (
+    seq integer PRIMARY KEY,
+    nombre varchar(100) NOT NULL,
+    apellido varchar(100) NOT NULL,
+    fecha_nacimiento date,
+    telefono varchar(30),
+    activo boolean NOT NULL
+) ON COMMIT DROP;
 
--- SUPERADMIN y ADMINISTRADOR: matriz completa.
-INSERT INTO public.rol_permisos (rol_id, permiso_id)
-SELECT r.id, p.id
-FROM public.roles r
-CROSS JOIN public.permisos p
-WHERE r.codigo IN ('SUPERADMIN', 'ADMINISTRADOR')
-ON CONFLICT DO NOTHING;
+INSERT INTO _demo_professors_desired
+SELECT n,
+       'DEMO · Profesor ' || lpad(n::text, 2, '0'),
+       CASE n WHEN 1 THEN 'Álvarez' WHEN 2 THEN 'Benítez' WHEN 3 THEN 'Castro'
+              WHEN 4 THEN 'Domínguez' WHEN 5 THEN 'Escobar' ELSE 'Fernández' END,
+       (SELECT anchor_date FROM _demo_config) - (interval '27 years' + n * interval '13 months'),
+       '+54 11 5555-' || lpad((1000 + n)::text, 4, '0'),
+       n <> 6
+FROM generate_series(1, 6) AS g(n);
 
--- SECRETARIA: operación diaria sin administración de usuarios/roles.
-INSERT INTO public.rol_permisos (rol_id, permiso_id)
-SELECT r.id, p.id
-FROM public.roles r
-JOIN public.permisos p ON p.codigo IN (
-    'PERM_APP_ACCESO',
-    'PERM_MENSUALIDADES_GENERAR_MANUAL',
-    'PERM_PAGOS_REGISTRAR',
-    'PERM_PAGOS_ANULAR',
-    'PERM_EGRESOS_ADMIN',
-    'PERM_STOCK_ADMIN',
-    'PERM_STOCK_VENDER',
-    'PERM_CREDITOS_ADMIN',
-    'PERM_CREDITOS_CONSUMIR',
-    'PERM_TARIFAS_HISTORICAS'
-)
-WHERE r.codigo = 'SECRETARIA'
-ON CONFLICT DO NOTHING;
+UPDATE public.profesores p
+SET apellido = d.apellido,
+    fecha_nacimiento = d.fecha_nacimiento,
+    telefono = d.telefono,
+    usuario_id = NULL,
+    activo = d.activo
+FROM _demo_professors_desired d
+WHERE p.nombre = d.nombre;
 
--- PROFESOR: acceso mínimo compatible con la seguridad global actual.
-INSERT INTO public.rol_permisos (rol_id, permiso_id)
-SELECT r.id, p.id
-FROM public.roles r
-JOIN public.permisos p ON p.codigo = 'PERM_APP_ACCESO'
-WHERE r.codigo = 'PROFESOR'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.profesores (nombre, apellido, fecha_nacimiento, telefono, usuario_id, activo, version)
+SELECT d.nombre, d.apellido, d.fecha_nacimiento, d.telefono, NULL, d.activo, 0
+FROM _demo_professors_desired d
+WHERE NOT EXISTS (SELECT 1 FROM public.profesores p WHERE p.nombre = d.nombre);
 
+UPDATE public.observaciones_profesores op
+SET fecha = (SELECT anchor_date - 20 FROM _demo_config),
+    activa = TRUE
+FROM public.profesores p, _demo_professors_desired d
+WHERE op.profesor_id = p.id
+  AND p.nombre = d.nombre
+  AND op.observacion = '[DEMO:PROFESOR:' || lpad(d.seq::text, 2, '0') || '] Seguimiento interno ficticio.';
 
--- ============================================================
--- 0. Usuario demo asignado a un rol productivo ya existente
--- ============================================================
-
-INSERT INTO public.usuarios (
-    id,
-    nombre_usuario,
-    contrasena,
-    rol_id,
-    activo,
-    auth_version,
-    password_changed_at,
-    version
-)
-SELECT
-    900001,
-    'admin',
-    '$2a$10$20gyPVFS3kpF8j8KZ.c0zer5c1LUzVWJS7Uu9rdvQVFxJp8Oc1hBa',
-    r.id,
-    TRUE,
-    0,
-    CURRENT_TIMESTAMP,
-    0
-FROM public.roles r
-WHERE r.codigo = 'ADMINISTRADOR'
-  AND NOT EXISTS (
-      SELECT 1
-      FROM public.usuarios u
-      WHERE lower(u.nombre_usuario) = 'admin'
-  );
-
-UPDATE public.usuarios u
-SET contrasena = '$2a$10$20gyPVFS3kpF8j8KZ.c0zer5c1LUzVWJS7Uu9rdvQVFxJp8Oc1hBa',
-    rol_id = (SELECT id FROM public.roles WHERE codigo = 'ADMINISTRADOR'),
-    activo = TRUE,
-    auth_version = 0,
-    password_changed_at = CURRENT_TIMESTAMP
-WHERE lower(u.nombre_usuario) = 'admin';
-
-INSERT INTO public.usuario_roles (usuario_id, rol_id, asignado_por_usuario_id)
-SELECT u.id, r.id, u.id
-FROM public.usuarios u
-JOIN public.roles r ON r.codigo = 'ADMINISTRADOR'
-WHERE lower(u.nombre_usuario) = 'admin'
-ON CONFLICT DO NOTHING;
-
--- ============================================================
--- 0B. Usuarios adicionales para demostrar RBAC
--- ============================================================
-
-INSERT INTO public.usuarios (
-    id, nombre_usuario, contrasena, rol_id, activo,
-    auth_version, password_changed_at, version
-)
-SELECT
-    v.id,
-    v.nombre_usuario,
-    '$2a$10$20gyPVFS3kpF8j8KZ.c0zer5c1LUzVWJS7Uu9rdvQVFxJp8Oc1hBa',
-    r.id,
-    TRUE,
-    0,
-    CURRENT_TIMESTAMP,
-    0
-FROM (
-    VALUES
-        (900002::bigint, 'secretaria', 'SECRETARIA'),
-        (900003::bigint, 'profesor', 'PROFESOR')
-) AS v(id, nombre_usuario, rol_codigo)
-JOIN public.roles r ON r.codigo = v.rol_codigo
+INSERT INTO public.observaciones_profesores (profesor_id, fecha, observacion, activa)
+SELECT p.id,
+       (SELECT anchor_date - 20 FROM _demo_config),
+       '[DEMO:PROFESOR:' || lpad(d.seq::text, 2, '0') || '] Seguimiento interno ficticio.',
+       TRUE
+FROM _demo_professors_desired d
+JOIN public.profesores p ON p.nombre = d.nombre
 WHERE NOT EXISTS (
-    SELECT 1
-    FROM public.usuarios u
-    WHERE lower(u.nombre_usuario) = lower(v.nombre_usuario)
+    SELECT 1 FROM public.observaciones_profesores op
+    WHERE op.profesor_id = p.id
+      AND op.observacion = '[DEMO:PROFESOR:' || lpad(d.seq::text, 2, '0') || '] Seguimiento interno ficticio.'
 );
 
-UPDATE public.usuarios u
-SET contrasena = '$2a$10$20gyPVFS3kpF8j8KZ.c0zer5c1LUzVWJS7Uu9rdvQVFxJp8Oc1hBa',
-    rol_id = r.id,
-    activo = TRUE,
-    auth_version = 0,
-    password_changed_at = CURRENT_TIMESTAMP
-FROM public.roles r
-WHERE (lower(u.nombre_usuario) = 'secretaria' AND r.codigo = 'SECRETARIA')
-   OR (lower(u.nombre_usuario) = 'profesor' AND r.codigo = 'PROFESOR');
-
-INSERT INTO public.usuario_roles (usuario_id, rol_id, asignado_por_usuario_id)
-SELECT u.id, r.id, admin.id
-FROM public.usuarios u
-JOIN public.roles r
-  ON (lower(u.nombre_usuario) = 'secretaria' AND r.codigo = 'SECRETARIA')
-  OR (lower(u.nombre_usuario) = 'profesor' AND r.codigo = 'PROFESOR')
-CROSS JOIN LATERAL (
-    SELECT id
-    FROM public.usuarios
-    WHERE lower(nombre_usuario) = 'admin'
-    LIMIT 1
-) admin
-ON CONFLICT DO NOTHING;
-
--- ============================================================
--- 1. Catálogos base
--- ============================================================
-
-INSERT INTO public.salones (id, nombre, descripcion, activo)
+INSERT INTO public.bonificaciones
+    (descripcion, porcentaje_descuento, valor_fijo, activo, observaciones)
 VALUES
-    (900001, 'Sala Azul', 'Salón principal con espejo completo y barra móvil', TRUE),
-    (900002, 'Sala Verde', 'Salón mediano para grupos iniciales y clases particulares', TRUE)
-ON CONFLICT (id) DO UPDATE
-SET nombre = EXCLUDED.nombre,
-    descripcion = EXCLUDED.descripcion,
-    activo = EXCLUDED.activo;
-
-INSERT INTO public.profesores (id, nombre, apellido, fecha_nacimiento, telefono, usuario_id, activo, version)
-VALUES
-    (900001, 'Valentina', 'Ramos', DATE '1989-04-18', '+54 9 223 555-1840', NULL, TRUE, 0),
-    (900002, 'Martín', 'Ledesma', DATE '1985-09-03', '+54 9 11 5555-2910', NULL, TRUE, 0),
-    (900003, 'Camila', 'Suárez', DATE '1994-01-25', '+54 9 221 555-8831', NULL, TRUE, 0)
-ON CONFLICT (id) DO UPDATE
-SET nombre = EXCLUDED.nombre,
-    apellido = EXCLUDED.apellido,
-    fecha_nacimiento = EXCLUDED.fecha_nacimiento,
-    telefono = EXCLUDED.telefono,
-    usuario_id = EXCLUDED.usuario_id,
-    activo = EXCLUDED.activo;
-
-UPDATE public.profesores
-SET usuario_id = (
-    SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'profesor'
-)
-WHERE id = 900002;
-
-INSERT INTO public.observaciones_profesores (id, profesor_id, fecha, observacion, activa)
-VALUES
-    (900001, 900001, DATE '2026-03-10', 'Coordina muestras semestrales y seguimiento de grupos infantiles.', TRUE),
-    (900002, 900002, DATE '2026-03-12', 'Disponible para reemplazos los sábados por la mañana.', TRUE)
-ON CONFLICT (id) DO UPDATE
-SET profesor_id = EXCLUDED.profesor_id,
-    fecha = EXCLUDED.fecha,
-    observacion = EXCLUDED.observacion,
-    activa = EXCLUDED.activa;
-
-INSERT INTO public.bonificaciones (id, descripcion, porcentaje_descuento, valor_fijo, activo, observaciones)
-VALUES
-    (900001, 'Hermanos 10%', 10.0000, 0.00, TRUE, 'Descuento habitual para dos o más alumnos del mismo grupo familiar.'),
-    (900002, 'Beca parcial acompañamiento', 25.0000, 0.00, TRUE, 'Beneficio sujeto a revisión trimestral.'),
-    (900003, 'Promoción ingreso julio', 0.0000, 5000.00, TRUE, 'Descuento fijo para nuevas inscripciones de mitad de año.')
-ON CONFLICT (id) DO UPDATE
-SET descripcion = EXCLUDED.descripcion,
-    porcentaje_descuento = EXCLUDED.porcentaje_descuento,
+    ('DEMO · Hermanos 10%', 10.0000, 0.00, TRUE, 'Beneficio ficticio por grupo familiar.'),
+    ('DEMO · Beca 25%', 25.0000, 0.00, TRUE, 'Beca parcial ficticia.'),
+    ('DEMO · Descuento fijo', 0.0000, 3500.00, TRUE, 'Descuento fijo de demostración.'),
+    ('DEMO · Beneficio inactivo', 5.0000, 0.00, FALSE, 'Histórico no asignable.')
+ON CONFLICT (descripcion) DO UPDATE
+SET porcentaje_descuento = EXCLUDED.porcentaje_descuento,
     valor_fijo = EXCLUDED.valor_fijo,
     activo = EXCLUDED.activo,
     observaciones = EXCLUDED.observaciones;
 
-INSERT INTO public.recargos (id, descripcion, porcentaje, valor_fijo, dia_del_mes_aplicacion, activo)
+INSERT INTO public.recargos
+    (descripcion, porcentaje, valor_fijo, dia_del_mes_aplicacion, activo)
 VALUES
-    (900001, 'Recargo por mora mensual', 8.0000, 0.00, 15, TRUE),
-    (900002, 'Recargo administrativo menor', 0.0000, 2500.00, NULL, TRUE)
-ON CONFLICT (id) DO UPDATE
-SET descripcion = EXCLUDED.descripcion,
-    porcentaje = EXCLUDED.porcentaje,
+    ('DEMO · Mora 5%', 5.0000, 0.00, 11, TRUE),
+    ('DEMO · Gestión fija', 0.0000, 2500.00, 16, TRUE),
+    ('DEMO · Recargo histórico', 8.0000, 0.00, 20, FALSE)
+ON CONFLICT (descripcion) DO UPDATE
+SET porcentaje = EXCLUDED.porcentaje,
     valor_fijo = EXCLUDED.valor_fijo,
     dia_del_mes_aplicacion = EXCLUDED.dia_del_mes_aplicacion,
     activo = EXCLUDED.activo;
 
-INSERT INTO public.metodo_pagos (id, descripcion, activo, recargo)
+INSERT INTO public.metodo_pagos (descripcion, activo, recargo)
 VALUES
-    (900001, 'Efectivo', TRUE, 0.0000),
-    (900002, 'Transferencia bancaria', TRUE, 0.0000),
-    (900003, 'Débito', TRUE, 2.0000)
-ON CONFLICT (id) DO UPDATE
-SET descripcion = EXCLUDED.descripcion,
-    activo = EXCLUDED.activo,
+    ('DEMO · Efectivo', TRUE, 0.0000),
+    ('DEMO · Transferencia', TRUE, 0.0000),
+    ('DEMO · Débito', TRUE, 0.0000),
+    ('DEMO · Crédito', TRUE, 3.0000)
+ON CONFLICT (descripcion) DO UPDATE
+SET activo = EXCLUDED.activo,
     recargo = EXCLUDED.recargo;
 
-INSERT INTO public.sub_conceptos (id, descripcion, activo)
+INSERT INTO public.sub_conceptos (descripcion, activo)
 VALUES
-    (900001, 'Indumentaria', TRUE),
-    (900002, 'Eventos y muestras', TRUE),
-    (900003, 'Administración', TRUE)
-ON CONFLICT (id) DO UPDATE
-SET descripcion = EXCLUDED.descripcion,
+    ('DEMO · Indumentaria', TRUE),
+    ('DEMO · Materiales', TRUE),
+    ('DEMO · Eventos', TRUE),
+    ('DEMO · Administración', TRUE)
+ON CONFLICT (descripcion) DO UPDATE SET activo = EXCLUDED.activo;
+
+CREATE TEMP TABLE _demo_concepts_desired (
+    seq integer PRIMARY KEY,
+    sub_description varchar(150) NOT NULL,
+    description varchar(150) NOT NULL,
+    price numeric(19,2) NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _demo_concepts_desired VALUES
+    (1, 'DEMO · Indumentaria', 'DEMO · Remera institucional', 12000.00),
+    (2, 'DEMO · Indumentaria', 'DEMO · Medias de danza', 8500.00),
+    (3, 'DEMO · Materiales', 'DEMO · Kit de práctica', 9500.00),
+    (4, 'DEMO · Materiales', 'DEMO · Cuaderno coreográfico', 6000.00),
+    (5, 'DEMO · Eventos', 'DEMO · Entrada muestra', 15000.00),
+    (6, 'DEMO · Eventos', 'DEMO · Taller especial', 18000.00),
+    (7, 'DEMO · Administración', 'DEMO · Certificado', 7000.00),
+    (8, 'DEMO · Administración', 'DEMO · Duplicado de credencial', 5000.00);
+
+INSERT INTO public.conceptos (descripcion, precio, sub_concepto_id, activo)
+SELECT d.description, d.price, sc.id, TRUE
+FROM _demo_concepts_desired d
+JOIN public.sub_conceptos sc ON sc.descripcion = d.sub_description
+ON CONFLICT (sub_concepto_id, descripcion) DO UPDATE
+SET precio = EXCLUDED.precio,
     activo = EXCLUDED.activo;
 
-INSERT INTO public.conceptos (id, descripcion, precio, sub_concepto_id, activo)
-VALUES
-    (900001, 'Remera institucional', 12000.00, 900001, TRUE),
-    (900002, 'Derecho de muestra anual', 18000.00, 900002, TRUE),
-    (900003, 'Certificado de asistencia', 3500.00, 900003, TRUE)
-ON CONFLICT (id) DO UPDATE
-SET descripcion = EXCLUDED.descripcion,
-    precio = EXCLUDED.precio,
-    sub_concepto_id = EXCLUDED.sub_concepto_id,
-    activo = EXCLUDED.activo;
+CREATE TEMP TABLE _demo_stocks_desired (
+    seq integer PRIMARY KEY,
+    nombre varchar(150) NOT NULL,
+    precio numeric(19,2) NOT NULL,
+    cantidad integer NOT NULL,
+    control boolean NOT NULL,
+    barcode varchar(100) NOT NULL
+) ON COMMIT DROP;
 
-INSERT INTO public.stocks (id, nombre, precio, cantidad_actual, requiere_control_de_stock, codigo_barras, activo, version)
-VALUES
-    (900001, 'REMERA INSTITUCIONAL NEGRA TALLE M', 8500.00, 18, TRUE, '7790000000010', TRUE, 0),
-    (900002, 'MEDIAS DE DANZA ROSA TALLE 34-38', 4200.00, 12, TRUE, '7790000000027', TRUE, 0),
-    (900003, 'BOTELLA PLÁSTICA ACADEMIA 750ML', 3900.00, 25, TRUE, '7790000000034', TRUE, 0)
-ON CONFLICT (id) DO UPDATE
-SET nombre = EXCLUDED.nombre,
-    precio = EXCLUDED.precio,
+INSERT INTO _demo_stocks_desired VALUES
+    (1, 'DEMO · Botella reutilizable', 5000.00, 21, TRUE, 'DEMO-STOCK-001'),
+    (2, 'DEMO · Remera negra', 9000.00, 17, TRUE, 'DEMO-STOCK-002'),
+    (3, 'DEMO · Medias rosa', 6500.00, 19, TRUE, 'DEMO-STOCK-003'),
+    (4, 'DEMO · Bolso pequeño', 11000.00, 18, TRUE, 'DEMO-STOCK-004'),
+    (5, 'DEMO · Cuaderno', 4500.00, 19, TRUE, 'DEMO-STOCK-005'),
+    (6, 'DEMO · Entrada digital', 7500.00, 20, FALSE, 'DEMO-STOCK-006');
+
+INSERT INTO public.stocks
+    (nombre, precio, cantidad_actual, requiere_control_de_stock, codigo_barras, activo, version)
+SELECT nombre, precio, cantidad, control, barcode, TRUE, 0
+FROM _demo_stocks_desired
+ON CONFLICT (nombre) DO UPDATE
+SET precio = EXCLUDED.precio,
     cantidad_actual = EXCLUDED.cantidad_actual,
     requiere_control_de_stock = EXCLUDED.requiere_control_de_stock,
     codigo_barras = EXCLUDED.codigo_barras,
     activo = EXCLUDED.activo;
 
--- ============================================================
--- 2. Alumnos, disciplinas, horarios e inscripciones
--- ============================================================
+-- Alumnos, disciplinas e inscripciones.
+CREATE TEMP TABLE _demo_disciplines_desired (
+    seq integer PRIMARY KEY,
+    nombre varchar(150) NOT NULL,
+    room_name varchar(100) NOT NULL,
+    professor_name varchar(100) NOT NULL,
+    cuota numeric(19,2) NOT NULL,
+    matricula numeric(19,2) NOT NULL
+) ON COMMIT DROP;
 
-INSERT INTO public.alumnos (
-    id, nombre, apellido, fecha_nacimiento, celular1, celular2, email, documento,
-    fecha_incorporacion, fecha_de_baja, nombre_padres, autorizado_para_salir_solo,
-    otras_notas, activo, version
-)
-VALUES
-    (900001, 'Sofía', 'Benítez', DATE '2015-08-21', '+54 9 223 555-1010', NULL, 'familia.benitez@example.com', '50123456', DATE '2026-02-15', NULL, 'Mariana Benítez / Lucas Ferreyra', FALSE, 'Retira madre o padre. Alergia leve a frutos secos.', TRUE, 0),
-    (900002, 'Martina', 'Gómez', DATE '2013-11-02', '+54 9 223 555-2020', NULL, 'martina.gomez.flia@example.com', '48765432', DATE '2026-03-01', NULL, 'Andrea Gómez', TRUE, 'Autorizada a retirarse con hermana mayor.', TRUE, 0),
-    (900003, 'Julián', 'Paz', DATE '2016-05-14', '+54 9 11 5555-3030', NULL, 'familia.paz@example.com', '51222333', DATE '2026-04-10', NULL, 'Natalia Paz / Diego Paz', FALSE, 'Solicita aviso previo por cambios de horario.', TRUE, 0),
-    (900004, 'Lara', 'Moreno', DATE '2012-01-30', '+54 9 221 555-4040', NULL, 'lara.moreno.flia@example.com', '47111222', DATE '2026-01-20', NULL, 'Carolina Moreno', TRUE, 'Participa en grupo avanzado.', TRUE, 0)
-ON CONFLICT (id) DO UPDATE
+INSERT INTO _demo_disciplines_desired
+SELECT n,
+       CASE n WHEN 1 THEN 'DEMO · Ballet inicial' WHEN 2 THEN 'DEMO · Jazz infantil'
+              WHEN 3 THEN 'DEMO · Urbano teen' WHEN 4 THEN 'DEMO · Contemporáneo'
+              WHEN 5 THEN 'DEMO · Ritmos adultos' ELSE 'DEMO · Entrenamiento escénico' END,
+       CASE ((n - 1) % 3) WHEN 0 THEN 'DEMO · Sala Norte'
+                            WHEN 1 THEN 'DEMO · Sala Sur' ELSE 'DEMO · Estudio Central' END,
+       'DEMO · Profesor ' || lpad(n::text, 2, '0'),
+       40000.00 + (n - 1) * 1500.00,
+       36000.00
+FROM generate_series(1, 6) AS g(n);
+
+UPDATE public.disciplinas d
+SET salon_id = s.id,
+    profesor_id = p.id,
+    valor_cuota = x.cuota,
+    matricula = x.matricula,
+    clase_suelta = 9000.00,
+    clase_prueba = 5000.00,
+    activo = TRUE
+FROM _demo_disciplines_desired x
+JOIN public.salones s ON s.nombre = x.room_name
+JOIN public.profesores p ON p.nombre = x.professor_name
+WHERE d.nombre = x.nombre;
+
+INSERT INTO public.disciplinas
+    (nombre, salon_id, profesor_id, valor_cuota, matricula, clase_suelta, clase_prueba, activo, version)
+SELECT x.nombre, s.id, p.id, x.cuota, x.matricula, 9000.00, 5000.00, TRUE, 0
+FROM _demo_disciplines_desired x
+JOIN public.salones s ON s.nombre = x.room_name
+JOIN public.profesores p ON p.nombre = x.professor_name
+WHERE NOT EXISTS (SELECT 1 FROM public.disciplinas d WHERE d.nombre = x.nombre);
+
+INSERT INTO public.disciplina_horarios (disciplina_id, dia_semana, horario_inicio, duracion)
+SELECT d.id,
+       CASE x.seq WHEN 1 THEN 'LUNES' WHEN 2 THEN 'MARTES' WHEN 3 THEN 'MIERCOLES'
+                  WHEN 4 THEN 'JUEVES' WHEN 5 THEN 'VIERNES' ELSE 'SABADO' END,
+       (time '17:00' + (x.seq - 1) * interval '30 minutes')::time,
+       1.50
+FROM _demo_disciplines_desired x
+JOIN public.disciplinas d ON d.nombre = x.nombre
+ON CONFLICT (disciplina_id, dia_semana, horario_inicio) DO UPDATE
+SET duracion = EXCLUDED.duracion;
+
+INSERT INTO public.disciplina_horarios (disciplina_id, dia_semana, horario_inicio, duracion)
+SELECT d.id,
+       CASE x.seq WHEN 1 THEN 'MIERCOLES' WHEN 2 THEN 'JUEVES' WHEN 3 THEN 'VIERNES'
+                  WHEN 4 THEN 'SABADO' ELSE 'MARTES' END,
+       (time '18:00' + (x.seq - 1) * interval '20 minutes')::time,
+       1.25
+FROM _demo_disciplines_desired x
+JOIN public.disciplinas d ON d.nombre = x.nombre
+WHERE x.seq <= 5
+ON CONFLICT (disciplina_id, dia_semana, horario_inicio) DO UPDATE
+SET duracion = EXCLUDED.duracion;
+
+INSERT INTO public.alumnos
+    (nombre, apellido, fecha_nacimiento, celular1, celular2, email, documento,
+     fecha_incorporacion, fecha_de_baja, nombre_padres, autorizado_para_salir_solo,
+     otras_notas, activo, version)
+SELECT
+    CASE ((n - 1) % 8) WHEN 0 THEN 'Sofía' WHEN 1 THEN 'Mateo' WHEN 2 THEN 'Valentina'
+         WHEN 3 THEN 'Joaquín' WHEN 4 THEN 'Martina' WHEN 5 THEN 'Thiago'
+         WHEN 6 THEN 'Camila' ELSE 'Benjamín' END || ' ' || lpad(n::text, 2, '0'),
+    CASE ((n - 1) % 7) WHEN 0 THEN 'Benítez' WHEN 1 THEN 'Gómez' WHEN 2 THEN 'Pérez'
+         WHEN 3 THEN 'Romero' WHEN 4 THEN 'Sosa' WHEN 5 THEN 'Torres' ELSE 'Vega' END,
+    (SELECT anchor_date FROM _demo_config) -
+        CASE WHEN n <= 18 THEN interval '12 years' + n * interval '2 months'
+             ELSE interval '25 years' + n * interval '5 months' END,
+    '+54 11 4444-' || lpad((2000 + n)::text, 4, '0'),
+    NULL,
+    'alumno' || lpad(n::text, 3, '0') || '@gestudio-demo.invalid',
+    'DEMO-DNI-A' || lpad(n::text, 3, '0'),
+    (SELECT anchor_date FROM _demo_config) - (90 + n),
+    CASE WHEN n = 28 THEN (SELECT anchor_date - 15 FROM _demo_config) ELSE NULL END,
+    CASE WHEN n <= 18 THEN 'Familia demo ' || lpad(n::text, 2, '0') ELSE NULL END,
+    n > 10,
+    CASE WHEN n = 1 THEN '[DEMO:SEED_V1] anchor=' || (SELECT anchor_date::text FROM _demo_config)
+         ELSE '[DEMO:ALUMNO:' || lpad(n::text, 3, '0') || '] Datos completamente ficticios.' END,
+    n <> 28,
+    0
+FROM generate_series(1, 28) AS g(n)
+ON CONFLICT (documento) WHERE documento IS NOT NULL DO UPDATE
 SET nombre = EXCLUDED.nombre,
     apellido = EXCLUDED.apellido,
     fecha_nacimiento = EXCLUDED.fecha_nacimiento,
     celular1 = EXCLUDED.celular1,
     celular2 = EXCLUDED.celular2,
     email = EXCLUDED.email,
-    documento = EXCLUDED.documento,
     fecha_incorporacion = EXCLUDED.fecha_incorporacion,
     fecha_de_baja = EXCLUDED.fecha_de_baja,
     nombre_padres = EXCLUDED.nombre_padres,
@@ -357,380 +485,481 @@ SET nombre = EXCLUDED.nombre,
     otras_notas = EXCLUDED.otras_notas,
     activo = EXCLUDED.activo;
 
-INSERT INTO public.disciplinas (
-    id, nombre, salon_id, profesor_id, valor_cuota, matricula,
-    clase_suelta, clase_prueba, activo, version
-)
-VALUES
-    (900001, 'Danza Jazz Infantil', 900001, 900001, 32000.00, 18000.00, 7000.00, 0.00, TRUE, 0),
-    (900002, 'Ballet Inicial', 900002, 900003, 28000.00, 16000.00, 6500.00, 0.00, TRUE, 0),
-    (900003, 'Urbano Teen', 900001, 900002, 35000.00, 20000.00, 8000.00, 0.00, TRUE, 0)
-ON CONFLICT (id) DO UPDATE
-SET nombre = EXCLUDED.nombre,
-    salon_id = EXCLUDED.salon_id,
-    profesor_id = EXCLUDED.profesor_id,
-    valor_cuota = EXCLUDED.valor_cuota,
-    matricula = EXCLUDED.matricula,
-    clase_suelta = EXCLUDED.clase_suelta,
-    clase_prueba = EXCLUDED.clase_prueba,
-    activo = EXCLUDED.activo;
+CREATE TEMP TABLE _demo_enrollments_desired ON COMMIT DROP AS
+SELECT
+    n AS seq,
+    'DEMO-DNI-A' || lpad(n::text, 3, '0') AS document,
+    ((n - 1) % 6) + 1 AS discipline_seq,
+    'ACTIVA'::varchar(12) AS state,
+    NULL::date AS end_date,
+    CASE WHEN n % 5 = 0 THEN 37000.00::numeric(19,2) ELSE NULL::numeric(19,2) END AS custom_cost
+FROM generate_series(1, 26) AS g(n)
+UNION ALL
+SELECT
+    26 + n,
+    'DEMO-DNI-A' || lpad(n::text, 3, '0'),
+    (n % 6) + 1,
+    CASE WHEN n = 7 THEN 'INACTIVA' WHEN n = 8 THEN 'FINALIZADA' ELSE 'ACTIVA' END,
+    CASE WHEN n >= 7 THEN (SELECT anchor_date - 25 FROM _demo_config) ELSE NULL END,
+    NULL::numeric(19,2)
+FROM generate_series(1, 8) AS g(n);
 
-INSERT INTO public.disciplina_horarios (id, disciplina_id, dia_semana, horario_inicio, duracion)
-VALUES
-    (900001, 900001, 'LUNES', TIME '17:30', 1.00),
-    (900002, 900001, 'MIERCOLES', TIME '17:30', 1.00),
-    (900003, 900002, 'MARTES', TIME '18:00', 1.00),
-    (900004, 900002, 'JUEVES', TIME '18:00', 1.00),
-    (900005, 900003, 'SABADO', TIME '10:30', 1.50)
-ON CONFLICT (id) DO UPDATE
-SET disciplina_id = EXCLUDED.disciplina_id,
-    dia_semana = EXCLUDED.dia_semana,
-    horario_inicio = EXCLUDED.horario_inicio,
-    duracion = EXCLUDED.duracion;
+UPDATE public.inscripciones i
+SET bonificacion_id = CASE WHEN x.seq % 3 = 0 THEN b.id ELSE NULL END,
+    fecha_inscripcion = (SELECT anchor_date - (160 + x.seq) FROM _demo_config),
+    fecha_baja = x.end_date,
+    estado = x.state,
+    costo_particular = x.custom_cost
+FROM _demo_enrollments_desired x
+JOIN public.alumnos a ON a.documento = x.document
+JOIN _demo_disciplines_desired dd ON dd.seq = x.discipline_seq
+JOIN public.disciplinas d ON d.nombre = dd.nombre
+LEFT JOIN public.bonificaciones b ON b.descripcion = 'DEMO · Hermanos 10%'
+WHERE i.alumno_id = a.id
+  AND i.disciplina_id = d.id;
 
-INSERT INTO public.inscripciones (
-    id, alumno_id, disciplina_id, bonificacion_id, fecha_inscripcion,
-    fecha_baja, estado, costo_particular, version
-)
-VALUES
-    (900001, 900001, 900001, 900001, DATE '2026-02-15', NULL, 'ACTIVA', NULL, 0),
-    (900002, 900002, 900002, NULL, DATE '2026-03-01', NULL, 'ACTIVA', NULL, 0),
-    (900003, 900003, 900001, 900003, DATE '2026-04-10', NULL, 'ACTIVA', 30000.00, 0),
-    (900004, 900004, 900003, 900002, DATE '2026-01-20', NULL, 'ACTIVA', NULL, 0)
-ON CONFLICT (id) DO UPDATE
-SET alumno_id = EXCLUDED.alumno_id,
-    disciplina_id = EXCLUDED.disciplina_id,
-    bonificacion_id = EXCLUDED.bonificacion_id,
-    fecha_inscripcion = EXCLUDED.fecha_inscripcion,
-    fecha_baja = EXCLUDED.fecha_baja,
-    estado = EXCLUDED.estado,
-    costo_particular = EXCLUDED.costo_particular;
+INSERT INTO public.inscripciones
+    (alumno_id, disciplina_id, bonificacion_id, fecha_inscripcion, fecha_baja, estado, costo_particular, version)
+SELECT a.id,
+       d.id,
+       CASE WHEN x.seq % 3 = 0 THEN b.id ELSE NULL END,
+       (SELECT anchor_date - (160 + x.seq) FROM _demo_config),
+       x.end_date,
+       x.state,
+       x.custom_cost,
+       0
+FROM _demo_enrollments_desired x
+JOIN public.alumnos a ON a.documento = x.document
+JOIN _demo_disciplines_desired dd ON dd.seq = x.discipline_seq
+JOIN public.disciplinas d ON d.nombre = dd.nombre
+LEFT JOIN public.bonificaciones b ON b.descripcion = 'DEMO · Hermanos 10%'
+WHERE NOT EXISTS (
+    SELECT 1 FROM public.inscripciones i
+    WHERE i.alumno_id = a.id AND i.disciplina_id = d.id
+);
 
--- ============================================================
--- 3. Tarifas históricas y condiciones económicas
--- ============================================================
-
-INSERT INTO public.disciplina_tarifas (
-    id, disciplina_id, vigente_desde, valor_cuota, matricula,
-    clase_suelta, clase_prueba, motivo, creada_por_usuario_id, created_at, version
-)
-VALUES
-    (900001, 900001, DATE '2026-01-01', 30000.00, 17000.00, 6500.00, 0.00, 'Tarifa inicial temporada 2026', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0),
-    (900002, 900001, DATE '2026-07-01', 32000.00, 18000.00, 7000.00, 0.00, 'Actualización julio 2026', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0),
-    (900003, 900002, DATE '2026-01-01', 28000.00, 16000.00, 6500.00, 0.00, 'Tarifa inicial temporada 2026', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0),
-    (900004, 900003, DATE '2026-01-01', 35000.00, 20000.00, 8000.00, 0.00, 'Tarifa inicial temporada 2026', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0)
-ON CONFLICT (id) DO UPDATE
-SET disciplina_id = EXCLUDED.disciplina_id,
-    vigente_desde = EXCLUDED.vigente_desde,
-    valor_cuota = EXCLUDED.valor_cuota,
+-- Vigencias económicas.
+INSERT INTO public.disciplina_tarifas
+    (disciplina_id, vigente_desde, valor_cuota, matricula, clase_suelta, clase_prueba,
+     motivo, creada_por_usuario_id, created_at, version)
+SELECT d.id,
+       periods.start_date,
+       CASE WHEN periods.current_rate THEN dd.cuota ELSE dd.cuota - 5000.00 END,
+       dd.matricula,
+       9000.00,
+       5000.00,
+       CASE WHEN periods.current_rate THEN '[DEMO:TARIFA] Vigencia actual.'
+            ELSE '[DEMO:TARIFA] Vigencia histórica.' END,
+       u.id,
+       (SELECT anchor_ts FROM _demo_config) + dd.seq * interval '1 second',
+       0
+FROM _demo_disciplines_desired dd
+JOIN public.disciplinas d ON d.nombre = dd.nombre
+CROSS JOIN LATERAL (
+    VALUES
+        ((SELECT month_2 - interval '3 months' FROM _demo_config)::date, FALSE),
+        ((SELECT month_0 FROM _demo_config), TRUE)
+) AS periods(start_date, current_rate)
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (disciplina_id, vigente_desde) DO UPDATE
+SET valor_cuota = EXCLUDED.valor_cuota,
     matricula = EXCLUDED.matricula,
     clase_suelta = EXCLUDED.clase_suelta,
     clase_prueba = EXCLUDED.clase_prueba,
     motivo = EXCLUDED.motivo,
-    creada_por_usuario_id = EXCLUDED.creada_por_usuario_id;
+    creada_por_usuario_id = EXCLUDED.creada_por_usuario_id,
+    created_at = EXCLUDED.created_at;
 
-INSERT INTO public.inscripcion_condiciones_economicas (
-    id, inscripcion_id, vigente_desde, costo_particular, bonificacion_id,
-    bonificacion_descripcion_snapshot, bonificacion_porcentaje_snapshot,
-    bonificacion_valor_fijo_snapshot, motivo, creada_por_usuario_id, created_at, version
-)
-VALUES
-    (900001, 900001, DATE '2026-02-15', NULL, 900001, 'Hermanos 10%', 10.0000, 0.00, 'Condición inicial de inscripción', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0),
-    (900002, 900002, DATE '2026-03-01', NULL, NULL, NULL, 0.0000, 0.00, 'Sin bonificación inicial', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0),
-    (900003, 900003, DATE '2026-04-10', 30000.00, 900003, 'Promoción ingreso julio', 0.0000, 5000.00, 'Costo particular acordado por grupo familiar', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0),
-    (900004, 900004, DATE '2026-01-20', NULL, 900002, 'Beca parcial acompañamiento', 25.0000, 0.00, 'Beca parcial aprobada por dirección', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, 0)
-ON CONFLICT (id) DO UPDATE
-SET inscripcion_id = EXCLUDED.inscripcion_id,
-    vigente_desde = EXCLUDED.vigente_desde,
-    costo_particular = EXCLUDED.costo_particular,
+CREATE TEMP TABLE _demo_enrollment_ids ON COMMIT DROP AS
+SELECT i.id,
+       a.id AS student_id,
+       a.documento,
+       i.disciplina_id,
+       row_number() OVER (ORDER BY a.documento, d.nombre) AS seq
+FROM public.inscripciones i
+JOIN public.alumnos a ON a.id = i.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+JOIN public.disciplinas d ON d.id = i.disciplina_id AND d.nombre LIKE 'DEMO · %';
+
+CREATE TEMP TABLE _demo_conditions_desired ON COMMIT DROP AS
+SELECT e.id AS enrollment_id,
+       (SELECT month_2 - interval '3 months' FROM _demo_config)::date AS start_date,
+       CASE WHEN e.seq % 5 = 0 THEN 37000.00::numeric(19,2) ELSE NULL::numeric(19,2) END AS custom_cost,
+       CASE WHEN e.seq % 3 = 0 THEN b.id ELSE NULL END AS bonus_id,
+       CASE WHEN e.seq % 3 = 0 THEN b.descripcion ELSE NULL END AS bonus_description,
+       CASE WHEN e.seq % 3 = 0 THEN b.porcentaje_descuento ELSE 0.0000 END AS bonus_percent,
+       0.00::numeric(19,2) AS bonus_fixed,
+       '[DEMO:CONDICION] Condición histórica.'::varchar(500) AS reason,
+       e.seq
+FROM _demo_enrollment_ids e
+LEFT JOIN public.bonificaciones b ON b.descripcion = 'DEMO · Hermanos 10%'
+UNION ALL
+SELECT e.id,
+       (SELECT month_0 FROM _demo_config),
+       CASE WHEN e.seq % 2 = 0 THEN 39000.00::numeric(19,2) ELSE NULL::numeric(19,2) END,
+       b.id,
+       b.descripcion,
+       b.porcentaje_descuento,
+       b.valor_fijo,
+       '[DEMO:CONDICION] Cambio de condición actual.',
+       100 + e.seq
+FROM _demo_enrollment_ids e
+JOIN public.bonificaciones b ON b.descripcion = 'DEMO · Beca 25%'
+WHERE e.seq <= 6;
+
+INSERT INTO public.inscripcion_condiciones_economicas
+    (inscripcion_id, vigente_desde, costo_particular, bonificacion_id,
+     bonificacion_descripcion_snapshot, bonificacion_porcentaje_snapshot,
+     bonificacion_valor_fijo_snapshot, motivo, creada_por_usuario_id, created_at, version)
+SELECT x.enrollment_id,
+       x.start_date,
+       x.custom_cost,
+       x.bonus_id,
+       x.bonus_description,
+       x.bonus_percent,
+       x.bonus_fixed,
+       x.reason,
+       u.id,
+       (SELECT anchor_ts FROM _demo_config) + x.seq * interval '1 second',
+       0
+FROM _demo_conditions_desired x
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (inscripcion_id, vigente_desde) DO UPDATE
+SET costo_particular = EXCLUDED.costo_particular,
     bonificacion_id = EXCLUDED.bonificacion_id,
     bonificacion_descripcion_snapshot = EXCLUDED.bonificacion_descripcion_snapshot,
     bonificacion_porcentaje_snapshot = EXCLUDED.bonificacion_porcentaje_snapshot,
     bonificacion_valor_fijo_snapshot = EXCLUDED.bonificacion_valor_fijo_snapshot,
     motivo = EXCLUDED.motivo,
-    creada_por_usuario_id = EXCLUDED.creada_por_usuario_id;
+    creada_por_usuario_id = EXCLUDED.creada_por_usuario_id,
+    created_at = EXCLUDED.created_at;
 
--- ============================================================
--- 4. Mensualidades, matrículas y asistencia
--- ============================================================
+-- Mensualidades, matrículas y asistencias.
+CREATE TEMP TABLE _demo_monthly_desired ON COMMIT DROP AS
+SELECT e.id AS enrollment_id,
+       extract(year FROM period.start_date)::integer AS year_value,
+       extract(month FROM period.start_date)::integer AS month_value,
+       period.start_date AS period_start,
+       e.seq
+FROM _demo_enrollment_ids e
+CROSS JOIN LATERAL (
+    VALUES ((SELECT month_2 FROM _demo_config)), ((SELECT month_1 FROM _demo_config))
+) AS period(start_date)
+UNION ALL
+SELECT e.id,
+       extract(year FROM (SELECT month_0 FROM _demo_config))::integer,
+       extract(month FROM (SELECT month_0 FROM _demo_config))::integer,
+       (SELECT month_0 FROM _demo_config),
+       100 + e.seq
+FROM _demo_enrollment_ids e
+JOIN _demo_enrollments_desired desired
+  ON desired.document = e.documento
+ AND desired.discipline_seq = (
+      SELECT dd.seq FROM public.disciplinas d
+      JOIN _demo_disciplines_desired dd ON dd.nombre = d.nombre
+      WHERE d.id = e.disciplina_id
+ )
+WHERE desired.seq IN (1, 2);
 
-INSERT INTO public.mensualidades (
-    id, inscripcion_id, bonificacion_id, recargo_id, anio, mes,
-    fecha_generacion, fecha_vencimiento, descripcion, estado, version
-)
-VALUES
-    (900001, 900001, 900001, NULL, 2026, 7, DATE '2026-07-01', DATE '2026-07-10', 'Cuota julio 2026 - Danza Jazz Infantil', 'EMITIDA', 0),
-    (900002, 900002, NULL, 900001, 2026, 7, DATE '2026-07-01', DATE '2026-07-10', 'Cuota julio 2026 - Ballet Inicial', 'EMITIDA', 0),
-    (900003, 900004, 900002, NULL, 2026, 7, DATE '2026-07-01', DATE '2026-07-10', 'Cuota julio 2026 - Urbano Teen', 'EMITIDA', 0)
-ON CONFLICT (id) DO UPDATE
-SET inscripcion_id = EXCLUDED.inscripcion_id,
-    bonificacion_id = EXCLUDED.bonificacion_id,
+INSERT INTO public.mensualidades
+    (inscripcion_id, bonificacion_id, recargo_id, anio, mes, fecha_generacion,
+     fecha_vencimiento, descripcion, estado, version)
+SELECT x.enrollment_id,
+       CASE WHEN x.seq % 3 = 0 THEN b.id ELSE NULL END,
+       CASE WHEN x.seq % 7 = 0 THEN r.id ELSE NULL END,
+       x.year_value,
+       x.month_value,
+       x.period_start,
+       x.period_start + 9,
+       'DEMO · Cuota ' || to_char(x.period_start, 'MM/YYYY'),
+       'EMITIDA',
+       0
+FROM _demo_monthly_desired x
+LEFT JOIN public.bonificaciones b ON b.descripcion = 'DEMO · Hermanos 10%'
+LEFT JOIN public.recargos r ON r.descripcion = 'DEMO · Mora 5%'
+ON CONFLICT (inscripcion_id, anio, mes) DO UPDATE
+SET bonificacion_id = EXCLUDED.bonificacion_id,
     recargo_id = EXCLUDED.recargo_id,
-    anio = EXCLUDED.anio,
-    mes = EXCLUDED.mes,
     fecha_generacion = EXCLUDED.fecha_generacion,
     fecha_vencimiento = EXCLUDED.fecha_vencimiento,
     descripcion = EXCLUDED.descripcion,
     estado = EXCLUDED.estado;
 
-INSERT INTO public.matriculas (id, alumno_id, anio, fecha_emision, estado, version)
-VALUES
-    (900001, 900001, 2026, DATE '2026-02-15', 'EMITIDA', 0),
-    (900002, 900002, 2026, DATE '2026-03-01', 'EMITIDA', 0),
-    (900003, 900004, 2026, DATE '2026-01-20', 'EMITIDA', 0)
-ON CONFLICT (id) DO UPDATE
-SET alumno_id = EXCLUDED.alumno_id,
-    anio = EXCLUDED.anio,
-    fecha_emision = EXCLUDED.fecha_emision,
+INSERT INTO public.matriculas (alumno_id, anio, fecha_emision, estado, version)
+SELECT a.id,
+       extract(year FROM (SELECT anchor_date FROM _demo_config))::integer,
+       make_date(extract(year FROM (SELECT anchor_date FROM _demo_config))::integer, 2, 15),
+       'EMITIDA',
+       0
+FROM public.alumnos a
+WHERE a.documento BETWEEN 'DEMO-DNI-A001' AND 'DEMO-DNI-A026'
+ON CONFLICT (alumno_id, anio) DO UPDATE
+SET fecha_emision = EXCLUDED.fecha_emision,
     estado = EXCLUDED.estado;
 
-INSERT INTO public.asistencias_mensuales (id, disciplina_id, mes, anio)
-VALUES
-    (900001, 900001, 7, 2026),
-    (900002, 900002, 7, 2026),
-    (900003, 900003, 7, 2026)
-ON CONFLICT (id) DO UPDATE
-SET disciplina_id = EXCLUDED.disciplina_id,
-    mes = EXCLUDED.mes,
-    anio = EXCLUDED.anio;
+INSERT INTO public.asistencias_mensuales (disciplina_id, mes, anio)
+SELECT d.id,
+       extract(month FROM (SELECT month_1 FROM _demo_config))::integer,
+       extract(year FROM (SELECT month_1 FROM _demo_config))::integer
+FROM public.disciplinas d
+WHERE d.nombre LIKE 'DEMO · %'
+ON CONFLICT (disciplina_id, anio, mes) DO NOTHING;
 
-INSERT INTO public.asistencias_alumno_mensual (id, inscripcion_id, asistencia_mensual_id, observacion, activo)
-VALUES
-    (900001, 900001, 900001, 'Asistencia regular durante julio.', TRUE),
-    (900002, 900002, 900002, 'Avisó ausencia por viaje familiar.', TRUE),
-    (900003, 900004, 900003, 'Grupo avanzado con asistencia estable.', TRUE)
-ON CONFLICT (id) DO UPDATE
-SET inscripcion_id = EXCLUDED.inscripcion_id,
-    asistencia_mensual_id = EXCLUDED.asistencia_mensual_id,
-    observacion = EXCLUDED.observacion,
+CREATE TEMP TABLE _demo_attendance_enrollments ON COMMIT DROP AS
+SELECT id AS enrollment_id, disciplina_id
+FROM (
+    SELECT e.*,
+           i.estado,
+           row_number() OVER (PARTITION BY e.disciplina_id ORDER BY e.documento, e.id) AS position
+    FROM _demo_enrollment_ids e
+    JOIN public.inscripciones i ON i.id = e.id
+    WHERE i.estado = 'ACTIVA'
+) ranked
+WHERE position <= 3;
+
+INSERT INTO public.asistencias_alumno_mensual
+    (inscripcion_id, asistencia_mensual_id, observacion, activo)
+SELECT e.enrollment_id,
+       am.id,
+       '[DEMO:ASISTENCIA] Planilla ficticia del período anterior.',
+       TRUE
+FROM _demo_attendance_enrollments e
+JOIN public.asistencias_mensuales am
+  ON am.disciplina_id = e.disciplina_id
+ AND am.anio = extract(year FROM (SELECT month_1 FROM _demo_config))::integer
+ AND am.mes = extract(month FROM (SELECT month_1 FROM _demo_config))::integer
+ON CONFLICT (asistencia_mensual_id, inscripcion_id) DO UPDATE
+SET observacion = EXCLUDED.observacion,
     activo = EXCLUDED.activo;
 
-INSERT INTO public.asistencias_diarias (id, asistencia_alumno_mensual_id, fecha, estado, vigente)
-VALUES
-    (900001, 900001, DATE '2026-07-06', 'PRESENTE', TRUE),
-    (900002, 900001, DATE '2026-07-08', 'PRESENTE', TRUE),
-    (900003, 900002, DATE '2026-07-07', 'AUSENTE', TRUE),
-    (900004, 900003, DATE '2026-07-04', 'PRESENTE', TRUE)
-ON CONFLICT (id) DO UPDATE
-SET asistencia_alumno_mensual_id = EXCLUDED.asistencia_alumno_mensual_id,
-    fecha = EXCLUDED.fecha,
-    estado = EXCLUDED.estado,
+INSERT INTO public.asistencias_diarias
+    (asistencia_alumno_mensual_id, fecha, estado, vigente)
+SELECT aam.id,
+       (SELECT month_1 FROM _demo_config) + days.day_number - 1,
+       CASE WHEN (aam.id + days.day_number) % 4 = 0 THEN 'AUSENTE' ELSE 'PRESENTE' END,
+       TRUE
+FROM public.asistencias_alumno_mensual aam
+JOIN _demo_attendance_enrollments e ON e.enrollment_id = aam.inscripcion_id
+JOIN public.asistencias_mensuales am
+  ON am.id = aam.asistencia_mensual_id
+ AND am.disciplina_id = e.disciplina_id
+CROSS JOIN (VALUES (5), (12), (19)) AS days(day_number)
+ON CONFLICT (asistencia_alumno_mensual_id, fecha) DO UPDATE
+SET estado = EXCLUDED.estado,
     vigente = EXCLUDED.vigente;
 
--- ============================================================
--- 5. Cargos, ventas, pagos, caja, créditos y stock
--- ============================================================
-
-INSERT INTO public.ventas_stock (
-    id, alumno_id, stock_id, cantidad, precio_unitario, fecha, estado,
-    idempotency_key, request_hash, reversal_idempotency_key, reversal_request_hash, version
-)
-VALUES
-    (900001, 900002, 900001, 2, 8500.00, DATE '2026-07-05', 'REGISTRADA', 'demo-venta-stock-001', repeat('a', 64), NULL, NULL, 0)
-ON CONFLICT (id) DO UPDATE
+-- Ventas y cargos. Las claves naturales del namespace reemplazan IDs rígidos.
+INSERT INTO public.ventas_stock
+    (alumno_id, stock_id, cantidad, precio_unitario, fecha, estado,
+     idempotency_key, request_hash, reversal_idempotency_key, reversal_request_hash, version)
+SELECT a.id,
+       s.id,
+       CASE WHEN x.seq IN (2, 4, 6) THEN 2 ELSE 1 END,
+       x.precio,
+       (SELECT anchor_date - (12 - x.seq) FROM _demo_config),
+       CASE WHEN x.seq = 6 THEN 'ANULADA' ELSE 'REGISTRADA' END,
+       'demo-seed:v1:venta:' || lpad(x.seq::text, 3, '0'),
+       repeat(md5('demo-seed:v1:venta:' || lpad(x.seq::text, 3, '0')), 2),
+       CASE WHEN x.seq = 6 THEN 'demo-seed:v1:venta-reversa:006' ELSE NULL END,
+       CASE WHEN x.seq = 6 THEN repeat(md5('demo-seed:v1:venta-reversa:006'), 2) ELSE NULL END,
+       0
+FROM _demo_stocks_desired x
+JOIN public.stocks s ON s.codigo_barras = x.barcode
+JOIN public.alumnos a ON a.documento = 'DEMO-DNI-A' || lpad(x.seq::text, 3, '0')
+ON CONFLICT (idempotency_key) DO UPDATE
 SET alumno_id = EXCLUDED.alumno_id,
     stock_id = EXCLUDED.stock_id,
     cantidad = EXCLUDED.cantidad,
     precio_unitario = EXCLUDED.precio_unitario,
     fecha = EXCLUDED.fecha,
     estado = EXCLUDED.estado,
-    idempotency_key = EXCLUDED.idempotency_key,
     request_hash = EXCLUDED.request_hash,
     reversal_idempotency_key = EXCLUDED.reversal_idempotency_key,
     reversal_request_hash = EXCLUDED.reversal_request_hash;
 
-INSERT INTO public.cargos (
-    id, alumno_id, tipo, descripcion, importe_original, fecha_emision,
-    fecha_vencimiento, estado, mensualidad_id, matricula_id, concepto_id,
-    venta_stock_id, cargo_origen_id, idempotency_key, version, created_at
-)
-VALUES
-    (900001, 900001, 'MENSUALIDAD', 'Cuota julio 2026 - Danza Jazz Infantil', 32000.00, DATE '2026-07-01', DATE '2026-07-10', 'PARCIAL', 900001, NULL, NULL, NULL, NULL, 'demo-cargo-mensualidad-001', 0, CURRENT_TIMESTAMP),
-    (900002, 900002, 'MENSUALIDAD', 'Cuota julio 2026 - Ballet Inicial', 28000.00, DATE '2026-07-01', DATE '2026-07-10', 'PARCIAL', 900002, NULL, NULL, NULL, NULL, 'demo-cargo-mensualidad-002', 0, CURRENT_TIMESTAMP),
-    (900003, 900001, 'MATRICULA', 'Matrícula anual 2026 - Sofía Benítez', 18000.00, DATE '2026-02-15', DATE '2026-02-20', 'PENDIENTE', NULL, 900001, NULL, NULL, NULL, 'demo-cargo-matricula-001', 0, CURRENT_TIMESTAMP),
-    (900004, 900003, 'CONCEPTO', 'Certificado y materiales administrativos', 3500.00, DATE '2026-07-03', DATE '2026-07-15', 'PENDIENTE', NULL, NULL, 900003, NULL, NULL, 'demo-cargo-concepto-001', 0, CURRENT_TIMESTAMP),
-    (900005, 900002, 'VENTA_STOCK', 'Venta de remeras institucionales', 17000.00, DATE '2026-07-05', DATE '2026-07-20', 'PENDIENTE', NULL, NULL, NULL, 900001, NULL, 'demo-cargo-venta-stock-001', 0, CURRENT_TIMESTAMP),
-    (900006, 900002, 'RECARGO', 'Recargo administrativo menor sobre cuota julio', 2500.00, DATE '2026-07-16', DATE '2026-07-20', 'PENDIENTE', NULL, NULL, NULL, NULL, 900002, 'demo-cargo-recargo-001', 0, CURRENT_TIMESTAMP),
-    (900007, 900004, 'MENSUALIDAD', 'Cuota julio 2026 - Urbano Teen', 26250.00, DATE '2026-07-01', DATE '2026-07-10', 'PENDIENTE', 900003, NULL, NULL, NULL, NULL, 'demo-cargo-mensualidad-003', 0, CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO UPDATE
+CREATE TEMP TABLE _demo_monthly_charge_data ON COMMIT DROP AS
+SELECT m.id AS monthly_id,
+       i.alumno_id,
+       a.documento,
+       d.nombre AS discipline_name,
+       m.anio,
+       m.mes,
+       m.fecha_generacion,
+       m.fecha_vencimiento,
+       row_number() OVER (ORDER BY a.documento, d.nombre, m.anio, m.mes) AS seq
+FROM public.mensualidades m
+JOIN public.inscripciones i ON i.id = m.inscripcion_id
+JOIN public.alumnos a ON a.id = i.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+JOIN public.disciplinas d ON d.id = i.disciplina_id AND d.nombre LIKE 'DEMO · %';
+
+INSERT INTO public.cargos
+    (alumno_id, tipo, descripcion, importe_original, fecha_emision, fecha_vencimiento,
+     estado, mensualidad_id, matricula_id, concepto_id, venta_stock_id, cargo_origen_id,
+     idempotency_key, version, created_at)
+SELECT x.alumno_id,
+       'MENSUALIDAD',
+       'DEMO · ' || x.discipline_name || ' ' || lpad(x.mes::text, 2, '0') || '/' || x.anio,
+       CASE WHEN x.seq <= 10 THEN 24000.00 ELSE 40000.00 END,
+       x.fecha_generacion,
+       x.fecha_vencimiento,
+       'PENDIENTE',
+       x.monthly_id,
+       NULL, NULL, NULL, NULL,
+       'demo-seed:v1:cargo:mensualidad:' || x.documento || ':' || x.anio || ':' || lpad(x.mes::text, 2, '0') || ':' || lpad(x.seq::text, 3, '0'),
+       0,
+       (SELECT anchor_ts FROM _demo_config) + x.seq * interval '1 second'
+FROM _demo_monthly_charge_data x
+ON CONFLICT (idempotency_key) DO UPDATE
 SET alumno_id = EXCLUDED.alumno_id,
-    tipo = EXCLUDED.tipo,
     descripcion = EXCLUDED.descripcion,
     importe_original = EXCLUDED.importe_original,
     fecha_emision = EXCLUDED.fecha_emision,
     fecha_vencimiento = EXCLUDED.fecha_vencimiento,
     estado = EXCLUDED.estado,
     mensualidad_id = EXCLUDED.mensualidad_id,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.cargos
+    (alumno_id, tipo, descripcion, importe_original, fecha_emision, fecha_vencimiento,
+     estado, mensualidad_id, matricula_id, concepto_id, venta_stock_id, cargo_origen_id,
+     idempotency_key, version, created_at)
+SELECT m.alumno_id,
+       'MATRICULA',
+       'DEMO · Matrícula anual ' || m.anio,
+       36000.00,
+       m.fecha_emision,
+       m.fecha_emision + 5,
+       'PENDIENTE',
+       NULL, m.id, NULL, NULL, NULL,
+       'demo-seed:v1:cargo:matricula:' || a.documento || ':' || m.anio,
+       0,
+       (SELECT anchor_ts FROM _demo_config) + (100 + row_number() OVER (ORDER BY a.documento)) * interval '1 second'
+FROM public.matriculas m
+JOIN public.alumnos a ON a.id = m.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    descripcion = EXCLUDED.descripcion,
+    importe_original = EXCLUDED.importe_original,
+    fecha_emision = EXCLUDED.fecha_emision,
+    fecha_vencimiento = EXCLUDED.fecha_vencimiento,
+    estado = EXCLUDED.estado,
     matricula_id = EXCLUDED.matricula_id,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.cargos
+    (alumno_id, tipo, descripcion, importe_original, fecha_emision, fecha_vencimiento,
+     estado, mensualidad_id, matricula_id, concepto_id, venta_stock_id, cargo_origen_id,
+     idempotency_key, version, created_at)
+SELECT v.alumno_id,
+       'VENTA_STOCK',
+       'DEMO · Venta de ' || s.nombre,
+       v.cantidad * v.precio_unitario,
+       v.fecha,
+       v.fecha + 10,
+       CASE WHEN v.estado = 'ANULADA' THEN 'ANULADO' ELSE 'PENDIENTE' END,
+       NULL, NULL, NULL, v.id, NULL,
+       'demo-seed:v1:cargo:' || v.idempotency_key,
+       0,
+       (SELECT anchor_ts FROM _demo_config) + (140 + row_number() OVER (ORDER BY v.idempotency_key)) * interval '1 second'
+FROM public.ventas_stock v
+JOIN public.stocks s ON s.id = v.stock_id
+WHERE v.idempotency_key LIKE 'demo-seed:v1:venta:%'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    descripcion = EXCLUDED.descripcion,
+    importe_original = EXCLUDED.importe_original,
+    fecha_emision = EXCLUDED.fecha_emision,
+    fecha_vencimiento = EXCLUDED.fecha_vencimiento,
+    estado = EXCLUDED.estado,
+    venta_stock_id = EXCLUDED.venta_stock_id,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.cargos
+    (alumno_id, tipo, descripcion, importe_original, fecha_emision, fecha_vencimiento,
+     estado, mensualidad_id, matricula_id, concepto_id, venta_stock_id, cargo_origen_id,
+     idempotency_key, version, created_at)
+SELECT a.id,
+       'CONCEPTO',
+       x.description,
+       CASE WHEN x.seq = 1 THEN 12000.00 ELSE 50000.00 END,
+       (SELECT anchor_date - (9 - x.seq) FROM _demo_config),
+       (SELECT anchor_date + 7 FROM _demo_config),
+       'PENDIENTE',
+       NULL, NULL, c.id, NULL, NULL,
+       'demo-seed:v1:cargo:concepto:' || lpad(x.seq::text, 3, '0'),
+       0,
+       (SELECT anchor_ts FROM _demo_config) + (160 + x.seq) * interval '1 second'
+FROM _demo_concepts_desired x
+JOIN public.sub_conceptos sc ON sc.descripcion = x.sub_description
+JOIN public.conceptos c ON c.sub_concepto_id = sc.id AND c.descripcion = x.description
+JOIN public.alumnos a ON a.documento = 'DEMO-DNI-A' || lpad(x.seq::text, 3, '0')
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    descripcion = EXCLUDED.descripcion,
+    importe_original = EXCLUDED.importe_original,
+    fecha_emision = EXCLUDED.fecha_emision,
+    fecha_vencimiento = EXCLUDED.fecha_vencimiento,
+    estado = EXCLUDED.estado,
     concepto_id = EXCLUDED.concepto_id,
-    venta_stock_id = EXCLUDED.venta_stock_id,
+    created_at = EXCLUDED.created_at;
+
+CREATE TEMP TABLE _demo_surcharge_origins ON COMMIT DROP AS
+SELECT c.id,
+       c.alumno_id,
+       row_number() OVER (ORDER BY c.idempotency_key) AS seq
+FROM public.cargos c
+WHERE c.idempotency_key LIKE 'demo-seed:v1:cargo:mensualidad:%'
+ORDER BY c.idempotency_key
+LIMIT 5;
+
+INSERT INTO public.cargos
+    (alumno_id, tipo, descripcion, importe_original, fecha_emision, fecha_vencimiento,
+     estado, mensualidad_id, matricula_id, concepto_id, venta_stock_id, cargo_origen_id,
+     idempotency_key, version, created_at)
+SELECT x.alumno_id,
+       'RECARGO',
+       'DEMO · Recargo vinculado ' || lpad(x.seq::text, 2, '0'),
+       5000.00,
+       (SELECT anchor_date - 2 FROM _demo_config),
+       (SELECT anchor_date + 5 FROM _demo_config),
+       'PENDIENTE',
+       NULL, NULL, NULL, NULL, x.id,
+       'demo-seed:v1:cargo:recargo:' || lpad(x.seq::text, 3, '0'),
+       0,
+       (SELECT anchor_ts FROM _demo_config) + (180 + x.seq) * interval '1 second'
+FROM _demo_surcharge_origins x
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    descripcion = EXCLUDED.descripcion,
+    importe_original = EXCLUDED.importe_original,
+    fecha_emision = EXCLUDED.fecha_emision,
+    fecha_vencimiento = EXCLUDED.fecha_vencimiento,
+    estado = EXCLUDED.estado,
     cargo_origen_id = EXCLUDED.cargo_origen_id,
-    idempotency_key = EXCLUDED.idempotency_key;
+    created_at = EXCLUDED.created_at;
 
-INSERT INTO public.pagos (
-    id, alumno_id, metodo_pago_id, usuario_id, fecha, monto_recibido,
-    estado, idempotency_key, request_hash, reversal_idempotency_key,
-    reversal_request_hash, observaciones, motivo_anulacion, fecha_anulacion,
-    version, created_at
-)
-VALUES
-    (900001, 900001, 900002, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), DATE '2026-07-08', 20000.00, 'REGISTRADO', 'demo-pago-001', repeat('b', 64), NULL, NULL, 'Pago parcial de cuota julio por transferencia.', NULL, NULL, 0, CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO UPDATE
-SET alumno_id = EXCLUDED.alumno_id,
-    metodo_pago_id = EXCLUDED.metodo_pago_id,
-    usuario_id = EXCLUDED.usuario_id,
-    fecha = EXCLUDED.fecha,
-    monto_recibido = EXCLUDED.monto_recibido,
-    estado = EXCLUDED.estado,
-    idempotency_key = EXCLUDED.idempotency_key,
-    request_hash = EXCLUDED.request_hash,
-    reversal_idempotency_key = EXCLUDED.reversal_idempotency_key,
-    reversal_request_hash = EXCLUDED.reversal_request_hash,
-    observaciones = EXCLUDED.observaciones,
-    motivo_anulacion = EXCLUDED.motivo_anulacion,
-    fecha_anulacion = EXCLUDED.fecha_anulacion;
-
-INSERT INTO public.aplicaciones_pago (
-    id, pago_id, cargo_id, usuario_id, importe_aplicado, estado,
-    fecha, motivo_reversion, fecha_reversion, version, created_at
-)
-VALUES
-    (900001, 900001, 900001, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 20000.00, 'APLICADA', DATE '2026-07-08', NULL, NULL, 0, CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO UPDATE
-SET pago_id = EXCLUDED.pago_id,
-    cargo_id = EXCLUDED.cargo_id,
-    usuario_id = EXCLUDED.usuario_id,
-    importe_aplicado = EXCLUDED.importe_aplicado,
-    estado = EXCLUDED.estado,
-    fecha = EXCLUDED.fecha,
-    motivo_reversion = EXCLUDED.motivo_reversion,
-    fecha_reversion = EXCLUDED.fecha_reversion;
-
-INSERT INTO public.egresos (
-    id, fecha, monto, observaciones, metodo_pago_id, estado, usuario_id,
-    idempotency_key, request_hash, reversal_idempotency_key, reversal_request_hash,
-    motivo_anulacion, fecha_anulacion, version
-)
-VALUES
-    (900001, DATE '2026-07-08', 14500.00, 'Compra de artículos de limpieza y resma administrativa.', 900001, 'REGISTRADO', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-egreso-001', repeat('c', 64), NULL, NULL, NULL, NULL, 0)
-ON CONFLICT (id) DO UPDATE
-SET fecha = EXCLUDED.fecha,
-    monto = EXCLUDED.monto,
-    observaciones = EXCLUDED.observaciones,
-    metodo_pago_id = EXCLUDED.metodo_pago_id,
-    estado = EXCLUDED.estado,
-    usuario_id = EXCLUDED.usuario_id,
-    idempotency_key = EXCLUDED.idempotency_key,
-    request_hash = EXCLUDED.request_hash,
-    reversal_idempotency_key = EXCLUDED.reversal_idempotency_key,
-    reversal_request_hash = EXCLUDED.reversal_request_hash,
-    motivo_anulacion = EXCLUDED.motivo_anulacion,
-    fecha_anulacion = EXCLUDED.fecha_anulacion;
-
-INSERT INTO public.movimientos_caja (
-    id, tipo, fecha, importe, metodo_pago_id, pago_id, egreso_id,
-    movimiento_revertido_id, usuario_id, idempotency_key, motivo, created_at
-)
-VALUES
-    (900001, 'INGRESO_PAGO', DATE '2026-07-08', 20000.00, 900002, 900001, NULL, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-caja-ingreso-pago-001', NULL, CURRENT_TIMESTAMP),
-    (900002, 'EGRESO', DATE '2026-07-08', 14500.00, 900001, NULL, 900001, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-caja-egreso-001', NULL, CURRENT_TIMESTAMP),
-    (900003, 'AJUSTE_INGRESO', DATE '2026-07-08', 2500.00, 900001, NULL, NULL, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-caja-ajuste-ingreso-001', 'Ajuste inicial de caja para demo.', CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO UPDATE
-SET tipo = EXCLUDED.tipo,
-    fecha = EXCLUDED.fecha,
-    importe = EXCLUDED.importe,
-    metodo_pago_id = EXCLUDED.metodo_pago_id,
-    pago_id = EXCLUDED.pago_id,
-    egreso_id = EXCLUDED.egreso_id,
-    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
-    usuario_id = EXCLUDED.usuario_id,
-    idempotency_key = EXCLUDED.idempotency_key,
-    motivo = EXCLUDED.motivo;
-
-INSERT INTO public.movimientos_credito (
-    id, alumno_id, tipo, importe, pago_id, cargo_id, movimiento_revertido_id,
-    usuario_id, idempotency_key, request_hash, motivo, created_at
-)
-VALUES
-    (900001, 900002, 'AJUSTE_CREDITO', 8000.00, NULL, NULL, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-credito-ajuste-001', repeat('d', 64), 'Crédito cargado por saldo a favor informado por la familia.', CURRENT_TIMESTAMP),
-    (900002, 900002, 'CONSUMO', 5000.00, NULL, 900002, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-credito-consumo-001', repeat('e', 64), NULL, CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO UPDATE
-SET alumno_id = EXCLUDED.alumno_id,
-    tipo = EXCLUDED.tipo,
-    importe = EXCLUDED.importe,
-    pago_id = EXCLUDED.pago_id,
-    cargo_id = EXCLUDED.cargo_id,
-    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
-    usuario_id = EXCLUDED.usuario_id,
-    idempotency_key = EXCLUDED.idempotency_key,
-    request_hash = EXCLUDED.request_hash,
-    motivo = EXCLUDED.motivo;
-
-INSERT INTO public.movimientos_stock (
-    id, stock_id, tipo, cantidad, venta_stock_id, movimiento_revertido_id,
-    usuario_id, idempotency_key, motivo, created_at
-)
-VALUES
-    (900001, 900001, 'INGRESO', 20, NULL, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-stock-ingreso-001', 'Stock inicial de remeras para demo.', CURRENT_TIMESTAMP),
-    (900002, 900001, 'VENTA', 2, 900001, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-stock-venta-001', NULL, CURRENT_TIMESTAMP),
-    (900003, 900002, 'INGRESO', 12, NULL, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-stock-ingreso-002', 'Stock inicial de medias para demo.', CURRENT_TIMESTAMP),
-    (900004, 900003, 'INGRESO', 25, NULL, NULL, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'demo-stock-ingreso-003', 'Stock inicial de botellas para demo.', CURRENT_TIMESTAMP)
-ON CONFLICT (id) DO UPDATE
-SET stock_id = EXCLUDED.stock_id,
-    tipo = EXCLUDED.tipo,
-    cantidad = EXCLUDED.cantidad,
-    venta_stock_id = EXCLUDED.venta_stock_id,
-    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
-    usuario_id = EXCLUDED.usuario_id,
-    idempotency_key = EXCLUDED.idempotency_key,
-    motivo = EXCLUDED.motivo;
-
--- ============================================================
--- 6. Recibos y seguimiento de cargos
--- ============================================================
-
-INSERT INTO public.recibos (id, pago_id, storage_key, generado_at, enviado_at)
-VALUES
-    (900001, 900001, 'demo/recibos/recibo_900001.pdf', CURRENT_TIMESTAMP, NULL)
-ON CONFLICT (id) DO UPDATE
-SET pago_id = EXCLUDED.pago_id,
-    storage_key = EXCLUDED.storage_key,
-    generado_at = EXCLUDED.generado_at,
-    enviado_at = EXCLUDED.enviado_at;
-
-INSERT INTO public.recibos_pendientes (
-    id, pago_id, tipo, estado, intentos, next_attempt_at, idempotency_key,
-    claim_token, claimed_at, lease_until, ultimo_error, created_at, processed_at
-)
-VALUES
-    (900001, 900001, 'GENERAR_Y_ENVIAR', 'PENDIENTE', 0, CURRENT_TIMESTAMP, 'demo-recibo-pendiente-001', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP, NULL)
-ON CONFLICT (id) DO UPDATE
-SET pago_id = EXCLUDED.pago_id,
-    tipo = EXCLUDED.tipo,
-    estado = EXCLUDED.estado,
-    intentos = EXCLUDED.intentos,
-    next_attempt_at = EXCLUDED.next_attempt_at,
-    idempotency_key = EXCLUDED.idempotency_key,
-    claim_token = EXCLUDED.claim_token,
-    claimed_at = EXCLUDED.claimed_at,
-    lease_until = EXCLUDED.lease_until,
-    ultimo_error = EXCLUDED.ultimo_error,
-    processed_at = EXCLUDED.processed_at;
-
-INSERT INTO public.cargo_liquidaciones (
-    cargo_id, periodo_desde, tarifa_disciplina_id, condicion_inscripcion_id,
-    origen_precio, importe_base, descuento_porcentaje, descuento_importe,
-    recargo_porcentaje, recargo_importe, importe_final, formula_version,
-    observaciones, calculada_por_usuario_id, created_at
-)
-VALUES
-    (900001, DATE '2026-07-01', 900002, 900001, 'TARIFA_HISTORICA', 32000.00, 10.0000, 3200.00, 0.0000, 0.00, 32000.00, 1, 'Liquidación demo de cuota mensual con bonificación familiar.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP),
-    (900002, DATE '2026-07-01', 900003, 900002, 'TARIFA_HISTORICA', 28000.00, 0.0000, 0.00, 8.0000, 0.00, 28000.00, 1, 'Liquidación demo de cuota mensual con recargo asociado.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP),
-    (900003, DATE '2026-01-01', NULL, NULL, 'MANUAL_HISTORICO', 18000.00, 0.0000, 0.00, 0.0000, 0.00, 18000.00, 1, 'Matrícula anual demo.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP),
-    (900004, DATE '2026-07-01', NULL, NULL, 'MANUAL_HISTORICO', 3500.00, 0.0000, 0.00, 0.0000, 0.00, 3500.00, 1, 'Cargo administrativo demo.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP),
-    (900005, DATE '2026-07-01', NULL, NULL, 'MANUAL_HISTORICO', 17000.00, 0.0000, 0.00, 0.0000, 0.00, 17000.00, 1, 'Cargo generado por venta de stock demo.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP),
-    (900006, DATE '2026-07-01', NULL, NULL, 'MANUAL_HISTORICO', 2500.00, 0.0000, 0.00, 0.0000, 2500.00, 2500.00, 1, 'Recargo administrativo demo.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP),
-    (900007, DATE '2026-07-01', 900004, 900004, 'TARIFA_HISTORICA', 35000.00, 25.0000, 8750.00, 0.0000, 0.00, 26250.00, 1, 'Liquidación demo de beca parcial.', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP)
+INSERT INTO public.cargo_liquidaciones
+    (cargo_id, periodo_desde, tarifa_disciplina_id, condicion_inscripcion_id,
+     origen_precio, importe_base, descuento_porcentaje, descuento_importe,
+     recargo_porcentaje, recargo_importe, importe_final, formula_version,
+     observaciones, calculada_por_usuario_id, created_at)
+SELECT c.id,
+       date_trunc('month', c.fecha_emision)::date,
+       NULL,
+       NULL,
+       'MANUAL_HISTORICO',
+       c.importe_original,
+       0.0000,
+       0.00,
+       0.0000,
+       0.00,
+       c.importe_original,
+       1,
+       '[DEMO:LIQUIDACION] Snapshot sintético; no genera eventos productivos.',
+       u.id,
+       c.created_at
+FROM public.cargos c
+JOIN public.alumnos a ON a.id = c.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
 ON CONFLICT (cargo_id) DO UPDATE
 SET periodo_desde = EXCLUDED.periodo_desde,
     tarifa_disciplina_id = EXCLUDED.tarifa_disciplina_id,
@@ -744,201 +973,981 @@ SET periodo_desde = EXCLUDED.periodo_desde,
     importe_final = EXCLUDED.importe_final,
     formula_version = EXCLUDED.formula_version,
     observaciones = EXCLUDED.observaciones,
-    calculada_por_usuario_id = EXCLUDED.calculada_por_usuario_id;
+    calculada_por_usuario_id = EXCLUDED.calculada_por_usuario_id,
+    created_at = EXCLUDED.created_at;
 
-INSERT INTO public.cargo_eventos (
-    cargo_id, tipo, estado_anterior, estado_nuevo, saldo_anterior, saldo_nuevo,
-    referencia_tipo, referencia_id, idempotency_key, usuario_id, ocurrido_at,
-    correlation_id, metadata
+-- Pagos y aplicaciones. Cada pago agrupa como máximo dos cargos del mismo alumno.
+CREATE TEMP TABLE _demo_application_targets ON COMMIT DROP AS
+WITH target_charges AS (
+    SELECT c.id AS charge_id,
+           c.alumno_id,
+           a.documento,
+           'M'::text AS source_kind,
+           c.idempotency_key
+    FROM public.cargos c
+    JOIN public.alumnos a ON a.id = c.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+    WHERE c.tipo = 'MENSUALIDAD'
+      AND c.idempotency_key LIKE 'demo-seed:v1:cargo:mensualidad:%'
+    UNION ALL
+    SELECT c.id,
+           c.alumno_id,
+           a.documento,
+           'R'::text,
+           c.idempotency_key
+    FROM public.cargos c
+    JOIN public.alumnos a ON a.id = c.alumno_id
+    WHERE c.tipo = 'MATRICULA'
+      AND a.documento BETWEEN 'DEMO-DNI-A003' AND 'DEMO-DNI-A014'
+      AND c.idempotency_key LIKE 'demo-seed:v1:cargo:matricula:%'
+), numbered AS (
+    SELECT t.*,
+           row_number() OVER (ORDER BY t.documento, t.source_kind, t.idempotency_key) AS application_no,
+           row_number() OVER (PARTITION BY t.alumno_id ORDER BY t.source_kind, t.idempotency_key) AS student_application_no
+    FROM target_charges t
+), grouped AS (
+    SELECT n.*,
+           ((n.student_application_no - 1) / 2 + 1)::integer AS local_payment_no
+    FROM numbered n
+), payment_numbered AS (
+    SELECT g.*,
+           dense_rank() OVER (ORDER BY g.documento, g.local_payment_no)::integer AS payment_no
+    FROM grouped g
 )
-VALUES
-    (900001, 'EMITIDO', NULL, 'PENDIENTE', NULL, 32000.00, 'CARGO', 900001, 'demo-cargo-900001-emitido', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"demo": true}'::jsonb),
-    (900001, 'PAGO_APLICADO', 'PENDIENTE', 'PARCIAL', 32000.00, 12000.00, 'APLICACION_PAGO', 900001, 'demo-cargo-900001-pago-aplicado', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"importe": "20000.00"}'::jsonb),
-    (900002, 'EMITIDO', NULL, 'PENDIENTE', NULL, 28000.00, 'CARGO', 900002, 'demo-cargo-900002-emitido', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"demo": true}'::jsonb),
-    (900002, 'CREDITO_APLICADO', 'PENDIENTE', 'PARCIAL', 28000.00, 23000.00, 'MOVIMIENTO_CREDITO', 900002, 'demo-cargo-900002-credito-aplicado', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"importe": "5000.00"}'::jsonb),
-    (900003, 'EMITIDO', NULL, 'PENDIENTE', NULL, 18000.00, 'CARGO', 900003, 'demo-cargo-900003-emitido', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"demo": true}'::jsonb),
-    (900004, 'EMITIDO', NULL, 'PENDIENTE', NULL, 3500.00, 'CARGO', 900004, 'demo-cargo-900004-emitido', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"demo": true}'::jsonb),
-    (900005, 'EMITIDO', NULL, 'PENDIENTE', NULL, 17000.00, 'CARGO', 900005, 'demo-cargo-900005-emitido', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"demo": true}'::jsonb),
-    (900006, 'RECARGO_CREADO', NULL, 'PENDIENTE', NULL, 2500.00, 'CARGO', 900006, 'demo-cargo-900006-recargo-creado', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"cargoOrigenId": 900002}'::jsonb),
-    (900007, 'EMITIDO', NULL, 'PENDIENTE', NULL, 26250.00, 'CARGO', 900007, 'demo-cargo-900007-emitido', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP, NULL, '{"demo": true}'::jsonb)
-ON CONFLICT (idempotency_key) DO NOTHING;
-
--- ============================================================
--- 7. Seguridad, auditoría y notificaciones
--- ============================================================
-
-INSERT INTO public.refresh_sessions (
-    id, family_id, usuario_id, token_hash, auth_version, issued_at, expires_at,
-    used_at, revoked_at, revoke_reason, replaced_by_id, user_agent_hash, ip_hash
-)
-VALUES
-    ('11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), repeat('1', 64), 0, CURRENT_TIMESTAMP - INTERVAL '1 hour', CURRENT_TIMESTAMP + INTERVAL '30 days', NULL, NULL, NULL, NULL, repeat('2', 64), repeat('3', 64))
-ON CONFLICT (id) DO UPDATE
-SET usuario_id = EXCLUDED.usuario_id,
-    token_hash = EXCLUDED.token_hash,
-    auth_version = EXCLUDED.auth_version,
-    issued_at = EXCLUDED.issued_at,
-    expires_at = EXCLUDED.expires_at,
-    used_at = EXCLUDED.used_at,
-    revoked_at = EXCLUDED.revoked_at,
-    revoke_reason = EXCLUDED.revoke_reason,
-    replaced_by_id = EXCLUDED.replaced_by_id,
-    user_agent_hash = EXCLUDED.user_agent_hash,
-    ip_hash = EXCLUDED.ip_hash;
-
-INSERT INTO public.bootstrap_ejecuciones (tipo, usuario_id, ejecutado_at)
-VALUES
-    ('DEMO_SEED_ADMIN', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), CURRENT_TIMESTAMP)
-ON CONFLICT (tipo) DO UPDATE
-SET usuario_id = EXCLUDED.usuario_id,
-    ejecutado_at = EXCLUDED.ejecutado_at;
-
-INSERT INTO public.auditoria_eventos (
-    id, categoria, accion, entidad_tipo, entidad_id, actor_usuario_id,
-    actor_username_snapshot, actor_role_snapshot, ocurrido_at, fecha_negocio,
-    correlation_id, idempotency_key, estado_anterior, estado_nuevo, metadata
-)
-VALUES
-    (900001, 'SISTEMA', 'DEMO_SEED_EJECUTADO', 'DEMO', 'gestudio-demo', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'admin', 'ADMINISTRADOR', CURRENT_TIMESTAMP, CURRENT_DATE, NULL, 'demo-auditoria-seed-001', NULL, '{"estado": "demo cargada"}'::jsonb, '{"origen": "gestudio_demo_seed_full.sql"}'::jsonb),
-    (900002, 'SEGURIDAD', 'USUARIO_DEMO_DISPONIBLE', 'USUARIO', 'admin', (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'admin', 'ADMINISTRADOR', CURRENT_TIMESTAMP, CURRENT_DATE, NULL, 'demo-auditoria-admin-001', NULL, '{"usuario": "admin"}'::jsonb, '{"demo": true}'::jsonb)
-ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
-
-INSERT INTO public.notificaciones (
-    id, usuario_id, tipo, mensaje, fecha_creacion, fecha_negocio, dedup_key, leida
-)
-VALUES
-    (900001, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'DEMO', 'Demo cargada: hay alumnos, mensualidades, pagos, caja, stock y créditos para revisar.', CURRENT_TIMESTAMP, CURRENT_DATE, 'demo-notificacion-seed-001', FALSE),
-    (900002, (SELECT id FROM public.usuarios WHERE lower(nombre_usuario) = 'admin'), 'CAJA', 'La caja demo incluye un ingreso, un egreso y un ajuste menor.', CURRENT_TIMESTAMP, CURRENT_DATE, 'demo-notificacion-caja-001', FALSE)
-ON CONFLICT (id) DO UPDATE
-SET usuario_id = EXCLUDED.usuario_id,
-    tipo = EXCLUDED.tipo,
-    mensaje = EXCLUDED.mensaje,
-    fecha_creacion = EXCLUDED.fecha_creacion,
-    fecha_negocio = EXCLUDED.fecha_negocio,
-    dedup_key = EXCLUDED.dedup_key,
-    leida = EXCLUDED.leida;
-
--- ============================================================
--- 7B. Validaciones de consistencia de la demo
--- ============================================================
+SELECT p.charge_id,
+       p.alumno_id,
+       p.documento,
+       p.application_no::integer,
+       p.payment_no,
+       CASE WHEN p.application_no <= 78 THEN 24000.00::numeric(19,2)
+            WHEN p.application_no <= 80 THEN 33350.00::numeric(19,2)
+            ELSE 10000.00::numeric(19,2) END AS applied_amount
+FROM payment_numbered p;
 
 DO $$
-DECLARE
-    faltantes integer;
 BEGIN
-    SELECT count(*)
-    INTO faltantes
-    FROM (
-        VALUES
-            ('admin'),
-            ('secretaria'),
-            ('profesor')
-    ) AS esperados(nombre_usuario)
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM public.usuarios u
-        WHERE lower(u.nombre_usuario) = esperados.nombre_usuario
-          AND u.activo
-    );
-
-    IF faltantes > 0 THEN
-        RAISE EXCEPTION 'La migración demo no pudo crear todos los usuarios esperados';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM public.alumnos WHERE id BETWEEN 900001 AND 909999) THEN
-        RAISE EXCEPTION 'La migración demo no creó alumnos';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM public.cargos WHERE id BETWEEN 900001 AND 909999) THEN
-        RAISE EXCEPTION 'La migración demo no creó cargos';
-    END IF;
-
-    IF NOT EXISTS (SELECT 1 FROM public.pagos WHERE id BETWEEN 900001 AND 909999) THEN
-        RAISE EXCEPTION 'La migración demo no creó pagos';
-    END IF;
-
-    IF NOT EXISTS (
-        SELECT 1
-        FROM public.rol_permisos rp
-        JOIN public.roles r ON r.id = rp.rol_id
-        JOIN public.permisos p ON p.id = rp.permiso_id
-        WHERE r.codigo = 'ADMINISTRADOR'
-          AND p.codigo = 'PERM_TARIFAS_HISTORICAS'
-    ) THEN
-        RAISE EXCEPTION 'La matriz RBAC demo quedó incompleta';
+    IF (SELECT count(*) FROM _demo_application_targets) <> 82
+       OR (SELECT count(DISTINCT payment_no) FROM _demo_application_targets) <> 48
+       OR EXISTS (
+            SELECT 1
+            FROM _demo_application_targets t
+            JOIN public.cargos c ON c.id = t.charge_id
+            WHERE t.applied_amount > c.importe_original
+       ) THEN
+        RAISE EXCEPTION 'No se pudo construir la distribución determinista 82 aplicaciones / 48 pagos';
     END IF;
 END
 $$;
 
--- ============================================================
--- 8. Ajuste de secuencias identity para inserts futuros
--- ============================================================
+CREATE TEMP TABLE _demo_payments_desired ON COMMIT DROP AS
+SELECT t.payment_no,
+       t.alumno_id,
+       sum(t.applied_amount) + CASE WHEN t.payment_no = 1 THEN 18000.00 ELSE 0.00 END AS received_amount,
+       'demo-seed:v1:pago:' || lpad(t.payment_no::text, 3, '0') AS idempotency_key
+FROM _demo_application_targets t
+GROUP BY t.payment_no, t.alumno_id;
+
+INSERT INTO public.pagos
+    (alumno_id, metodo_pago_id, usuario_id, fecha, monto_recibido, estado,
+     idempotency_key, request_hash, reversal_idempotency_key, reversal_request_hash,
+     observaciones, motivo_anulacion, fecha_anulacion, version, created_at)
+SELECT x.alumno_id,
+       mp.id,
+       u.id,
+       (SELECT anchor_date FROM _demo_config) - ((48 - x.payment_no) % 28),
+       x.received_amount,
+       CASE WHEN x.payment_no = 48 THEN 'ANULADO' ELSE 'REGISTRADO' END,
+       x.idempotency_key,
+       repeat(md5(x.idempotency_key), 2),
+       CASE WHEN x.payment_no = 48 THEN 'demo-seed:v1:pago-reversa:048' ELSE NULL END,
+       CASE WHEN x.payment_no = 48 THEN repeat(md5('demo-seed:v1:pago-reversa:048'), 2) ELSE NULL END,
+       CASE WHEN x.payment_no = 1 THEN '[DEMO:PAGO] Incluye excedente para crédito.'
+            WHEN (SELECT count(*) FROM _demo_application_targets t WHERE t.payment_no = x.payment_no) = 2
+                THEN '[DEMO:PAGO] Distribuido entre dos cargos.'
+            ELSE '[DEMO:PAGO] Aplicado a un cargo.' END,
+       CASE WHEN x.payment_no = 48 THEN '[DEMO:PAGO] Anulación ficticia.' ELSE NULL END,
+       CASE WHEN x.payment_no = 48 THEN (SELECT anchor_ts + interval '6 minutes' FROM _demo_config) ELSE NULL END,
+       0,
+       (SELECT anchor_ts FROM _demo_config) + (200 + x.payment_no) * interval '1 second'
+FROM _demo_payments_desired x
+JOIN _demo_stocks_desired ordinal ON ordinal.seq = ((x.payment_no - 1) % 4) + 1
+JOIN public.metodo_pagos mp ON mp.descripcion = CASE ordinal.seq
+    WHEN 1 THEN 'DEMO · Efectivo' WHEN 2 THEN 'DEMO · Transferencia'
+    WHEN 3 THEN 'DEMO · Débito' ELSE 'DEMO · Crédito' END
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-caja'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    usuario_id = EXCLUDED.usuario_id,
+    fecha = EXCLUDED.fecha,
+    monto_recibido = EXCLUDED.monto_recibido,
+    estado = EXCLUDED.estado,
+    request_hash = EXCLUDED.request_hash,
+    reversal_idempotency_key = EXCLUDED.reversal_idempotency_key,
+    reversal_request_hash = EXCLUDED.reversal_request_hash,
+    observaciones = EXCLUDED.observaciones,
+    motivo_anulacion = EXCLUDED.motivo_anulacion,
+    fecha_anulacion = EXCLUDED.fecha_anulacion,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.aplicaciones_pago
+    (pago_id, cargo_id, usuario_id, importe_aplicado, estado, fecha,
+     motivo_reversion, fecha_reversion, version, created_at)
+SELECT p.id,
+       t.charge_id,
+       u.id,
+       t.applied_amount,
+       CASE WHEN t.payment_no = 48 THEN 'REVERTIDA' ELSE 'APLICADA' END,
+       p.fecha,
+       CASE WHEN t.payment_no = 48 THEN '[DEMO:PAGO] Aplicación revertida por anulación.' ELSE NULL END,
+       CASE WHEN t.payment_no = 48 THEN (SELECT anchor_ts + interval '6 minutes' FROM _demo_config) ELSE NULL END,
+       0,
+       (SELECT anchor_ts FROM _demo_config) + (260 + t.application_no) * interval '1 second'
+FROM _demo_application_targets t
+JOIN public.pagos p ON p.idempotency_key = 'demo-seed:v1:pago:' || lpad(t.payment_no::text, 3, '0')
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-caja'
+ON CONFLICT (pago_id, cargo_id) DO UPDATE
+SET usuario_id = EXCLUDED.usuario_id,
+    importe_aplicado = EXCLUDED.importe_aplicado,
+    estado = EXCLUDED.estado,
+    fecha = EXCLUDED.fecha,
+    motivo_reversion = EXCLUDED.motivo_reversion,
+    fecha_reversion = EXCLUDED.fecha_reversion,
+    created_at = EXCLUDED.created_at;
+
+-- Crédito: generación por excedente, consumos, reversiones y ajustes.
+CREATE TEMP TABLE _demo_credit_context ON COMMIT DROP AS
+SELECT c.id AS charge_id,
+       row_number() OVER (
+           ORDER BY CASE c.tipo WHEN 'VENTA_STOCK' THEN 1 WHEN 'CONCEPTO' THEN 2
+                                WHEN 'MATRICULA' THEN 3 ELSE 4 END,
+                    c.idempotency_key
+       )::integer AS seq
+FROM public.cargos c
+JOIN public.alumnos a ON a.id = c.alumno_id AND a.documento = 'DEMO-DNI-A001'
+WHERE c.estado <> 'ANULADO'
+  AND NOT EXISTS (SELECT 1 FROM _demo_application_targets t WHERE t.charge_id = c.id)
+ORDER BY seq
+LIMIT 4;
 
 DO $$
-DECLARE
-    t text;
-    seq text;
-    max_id bigint;
 BEGIN
-    FOREACH t IN ARRAY ARRAY[
-        'roles',
-        'usuarios',
-        'alumnos',
-        'salones',
-        'profesores',
-        'observaciones_profesores',
-        'bonificaciones',
-        'recargos',
-        'metodo_pagos',
-        'sub_conceptos',
-        'conceptos',
-        'stocks',
-        'disciplinas',
-        'disciplina_horarios',
-        'inscripciones',
-        'mensualidades',
-        'matriculas',
-        'asistencias_mensuales',
-        'asistencias_alumno_mensual',
-        'asistencias_diarias',
-        'ventas_stock',
-        'cargos',
-        'pagos',
-        'aplicaciones_pago',
-        'egresos',
-        'movimientos_caja',
-        'movimientos_credito',
-        'movimientos_stock',
-        'recibos',
-        'recibos_pendientes',
-        'notificaciones',
-        'auditoria_eventos',
-        'disciplina_tarifas',
-        'inscripcion_condiciones_economicas',
-        'cargo_eventos'
-    ] LOOP
-        SELECT pg_get_serial_sequence('public.' || t, 'id') INTO seq;
+    IF (SELECT count(*) FROM _demo_credit_context) <> 4 THEN
+        RAISE EXCEPTION 'No se pudieron resolver cuatro cargos de crédito del mismo alumno';
+    END IF;
+END
+$$;
 
-        IF seq IS NOT NULL THEN
-            EXECUTE format('SELECT max(id) FROM public.%I', t) INTO max_id;
+CREATE TEMP TABLE _demo_credit_originals (
+    seq integer PRIMARY KEY,
+    movement_type varchar(15) NOT NULL,
+    amount numeric(19,2) NOT NULL,
+    payment_no integer,
+    charge_seq integer,
+    reason varchar(500)
+) ON COMMIT DROP;
 
-            IF max_id IS NOT NULL THEN
-                EXECUTE format('SELECT setval(%L, %s, true)', seq, max_id);
-            END IF;
-        END IF;
-    END LOOP;
-END $$;
+INSERT INTO _demo_credit_originals VALUES
+    (1, 'GENERACION', 18000.00, 1, NULL, NULL),
+    (2, 'AJUSTE_CREDITO', 10000.00, NULL, NULL, '[DEMO:CREDITO] Ajuste positivo.'),
+    (3, 'AJUSTE_DEBITO', 2000.00, NULL, NULL, '[DEMO:CREDITO] Ajuste de débito.'),
+    (4, 'CONSUMO', 5000.00, NULL, 1, NULL),
+    (5, 'CONSUMO', 4000.00, NULL, 2, NULL),
+    (7, 'AJUSTE_CREDITO', 6000.00, NULL, NULL, '[DEMO:CREDITO] Segundo ajuste positivo.'),
+    (8, 'AJUSTE_DEBITO', 4000.00, NULL, NULL, '[DEMO:CREDITO] Segundo ajuste de débito.'),
+    (9, 'CONSUMO', 2000.00, NULL, 3, NULL),
+    (10, 'CONSUMO', 3000.00, NULL, 4, NULL);
+
+INSERT INTO public.movimientos_credito
+    (alumno_id, tipo, importe, pago_id, cargo_id, movimiento_revertido_id,
+     usuario_id, idempotency_key, request_hash, motivo, created_at)
+SELECT a.id,
+       x.movement_type,
+       x.amount,
+       p.id,
+       cc.charge_id,
+       NULL,
+       u.id,
+       'demo-seed:v1:credito:' || lpad(x.seq::text, 3, '0'),
+       repeat(md5('demo-seed:v1:credito:' || lpad(x.seq::text, 3, '0')), 2),
+       x.reason,
+       (SELECT anchor_ts FROM _demo_config) + (360 + x.seq) * interval '1 second'
+FROM _demo_credit_originals x
+JOIN public.alumnos a ON a.documento = 'DEMO-DNI-A001'
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-caja'
+LEFT JOIN public.pagos p
+  ON p.idempotency_key = 'demo-seed:v1:pago:' || lpad(x.payment_no::text, 3, '0')
+LEFT JOIN _demo_credit_context cc ON cc.seq = x.charge_seq
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    tipo = EXCLUDED.tipo,
+    importe = EXCLUDED.importe,
+    pago_id = EXCLUDED.pago_id,
+    cargo_id = EXCLUDED.cargo_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    request_hash = EXCLUDED.request_hash,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_credito
+    (alumno_id, tipo, importe, pago_id, cargo_id, movimiento_revertido_id,
+     usuario_id, idempotency_key, request_hash, motivo, created_at)
+SELECT original.alumno_id,
+       'REVERSO',
+       original.importe,
+       NULL,
+       NULL,
+       original.id,
+       u.id,
+       reversal.key_value,
+       repeat(md5(reversal.key_value), 2),
+       '[DEMO:CREDITO] Reversión de consumo.',
+       (SELECT anchor_ts FROM _demo_config) + reversal.seq * interval '1 second'
+FROM (VALUES
+    (6, 'demo-seed:v1:credito:006', 'demo-seed:v1:credito:005'),
+    (11, 'demo-seed:v1:credito:011', 'demo-seed:v1:credito:010')
+) AS reversal(seq, key_value, original_key)
+JOIN public.movimientos_credito original ON original.idempotency_key = reversal.original_key
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-caja'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET alumno_id = EXCLUDED.alumno_id,
+    tipo = EXCLUDED.tipo,
+    importe = EXCLUDED.importe,
+    pago_id = EXCLUDED.pago_id,
+    cargo_id = EXCLUDED.cargo_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    request_hash = EXCLUDED.request_hash,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+-- El estado materializado se deriva de aplicaciones y consumo neto de crédito.
+WITH paid AS (
+    SELECT ap.cargo_id, sum(ap.importe_aplicado) AS amount
+    FROM public.aplicaciones_pago ap
+    WHERE ap.estado = 'APLICADA'
+    GROUP BY ap.cargo_id
+), credit AS (
+    SELECT cargo_id, sum(amount) AS amount
+    FROM (
+        SELECT mc.cargo_id, mc.importe AS amount
+        FROM public.movimientos_credito mc
+        WHERE mc.tipo = 'CONSUMO'
+        UNION ALL
+        SELECT original.cargo_id, -reversal.importe
+        FROM public.movimientos_credito reversal
+        JOIN public.movimientos_credito original ON original.id = reversal.movimiento_revertido_id
+        WHERE reversal.tipo = 'REVERSO' AND original.tipo = 'CONSUMO'
+    ) movements
+    GROUP BY cargo_id
+), balances AS (
+    SELECT c.id,
+           c.estado,
+           c.importe_original,
+           c.venta_stock_id,
+           COALESCE(paid.amount, 0) AS paid_amount,
+           COALESCE(credit.amount, 0) AS credit_amount
+    FROM public.cargos c
+    JOIN public.alumnos a ON a.id = c.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+    LEFT JOIN paid ON paid.cargo_id = c.id
+    LEFT JOIN credit ON credit.cargo_id = c.id
+)
+UPDATE public.cargos c
+SET estado = CASE
+    WHEN balances.estado = 'ANULADO' OR EXISTS (
+        SELECT 1 FROM public.ventas_stock v WHERE v.id = balances.venta_stock_id AND v.estado = 'ANULADA'
+    ) THEN 'ANULADO'
+    WHEN balances.importe_original - balances.paid_amount - balances.credit_amount = 0 THEN 'PAGADO'
+    WHEN balances.importe_original - balances.paid_amount - balances.credit_amount < balances.importe_original THEN 'PARCIAL'
+    ELSE 'PENDIENTE'
+END
+FROM balances
+WHERE c.id = balances.id;
+
+-- Egresos y libro de caja.
+CREATE TEMP TABLE _demo_expenses_desired ON COMMIT DROP AS
+SELECT n AS seq,
+       (10000 + n * 1250)::numeric(19,2) AS amount,
+       CASE WHEN n = 7 THEN 'ANULADO'::varchar(10) ELSE 'REGISTRADO'::varchar(10) END AS state,
+       'demo-seed:v1:egreso:' || lpad(n::text, 3, '0') AS key_value
+FROM generate_series(1, 7) AS g(n);
+
+INSERT INTO public.egresos
+    (fecha, monto, observaciones, metodo_pago_id, estado, usuario_id,
+     idempotency_key, request_hash, reversal_idempotency_key, reversal_request_hash,
+     motivo_anulacion, fecha_anulacion, version)
+SELECT (SELECT anchor_date - (8 - x.seq) FROM _demo_config),
+       x.amount,
+       '[DEMO:EGRESO] Operación ficticia ' || lpad(x.seq::text, 2, '0') || '.',
+       mp.id,
+       x.state,
+       u.id,
+       x.key_value,
+       repeat(md5(x.key_value), 2),
+       CASE WHEN x.seq = 7 THEN 'demo-seed:v1:egreso-reversa:007' ELSE NULL END,
+       CASE WHEN x.seq = 7 THEN repeat(md5('demo-seed:v1:egreso-reversa:007'), 2) ELSE NULL END,
+       CASE WHEN x.seq = 7 THEN '[DEMO:EGRESO] Anulación ficticia.' ELSE NULL END,
+       CASE WHEN x.seq = 7 THEN (SELECT anchor_ts + interval '7 minutes' FROM _demo_config) ELSE NULL END,
+       0
+FROM _demo_expenses_desired x
+JOIN public.metodo_pagos mp ON mp.descripcion = CASE WHEN x.seq % 2 = 0
+    THEN 'DEMO · Transferencia' ELSE 'DEMO · Efectivo' END
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET fecha = EXCLUDED.fecha,
+    monto = EXCLUDED.monto,
+    observaciones = EXCLUDED.observaciones,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    estado = EXCLUDED.estado,
+    usuario_id = EXCLUDED.usuario_id,
+    request_hash = EXCLUDED.request_hash,
+    reversal_idempotency_key = EXCLUDED.reversal_idempotency_key,
+    reversal_request_hash = EXCLUDED.reversal_request_hash,
+    motivo_anulacion = EXCLUDED.motivo_anulacion,
+    fecha_anulacion = EXCLUDED.fecha_anulacion;
+
+INSERT INTO public.movimientos_caja
+    (tipo, fecha, importe, metodo_pago_id, pago_id, egreso_id,
+     movimiento_revertido_id, usuario_id, idempotency_key, motivo, created_at)
+SELECT 'INGRESO_PAGO',
+       p.fecha,
+       p.monto_recibido,
+       p.metodo_pago_id,
+       p.id,
+       NULL,
+       NULL,
+       u.id,
+       'demo-seed:v1:caja:pago:' || lpad(x.payment_no::text, 3, '0'),
+       NULL,
+       (SELECT anchor_ts FROM _demo_config) + (400 + x.payment_no) * interval '1 second'
+FROM _demo_payments_desired x
+JOIN public.pagos p ON p.idempotency_key = x.idempotency_key
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-caja'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET tipo = EXCLUDED.tipo,
+    fecha = EXCLUDED.fecha,
+    importe = EXCLUDED.importe,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    pago_id = EXCLUDED.pago_id,
+    egreso_id = EXCLUDED.egreso_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_caja
+    (tipo, fecha, importe, metodo_pago_id, pago_id, egreso_id,
+     movimiento_revertido_id, usuario_id, idempotency_key, motivo, created_at)
+SELECT 'REVERSO',
+       (SELECT anchor_date FROM _demo_config),
+       original.importe,
+       original.metodo_pago_id,
+       NULL,
+       NULL,
+       original.id,
+       u.id,
+       'demo-seed:v1:caja:reversa-pago:048',
+       '[DEMO:CAJA] Reversión del pago anulado.',
+       (SELECT anchor_ts + interval '7 minutes' FROM _demo_config)
+FROM public.movimientos_caja original
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-caja'
+WHERE original.idempotency_key = 'demo-seed:v1:caja:pago:048'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET tipo = EXCLUDED.tipo,
+    fecha = EXCLUDED.fecha,
+    importe = EXCLUDED.importe,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    pago_id = EXCLUDED.pago_id,
+    egreso_id = EXCLUDED.egreso_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_caja
+    (tipo, fecha, importe, metodo_pago_id, pago_id, egreso_id,
+     movimiento_revertido_id, usuario_id, idempotency_key, motivo, created_at)
+SELECT 'EGRESO',
+       e.fecha,
+       e.monto,
+       e.metodo_pago_id,
+       NULL,
+       e.id,
+       NULL,
+       u.id,
+       'demo-seed:v1:caja:egreso:' || lpad(x.seq::text, 3, '0'),
+       NULL,
+       (SELECT anchor_ts FROM _demo_config) + (460 + x.seq) * interval '1 second'
+FROM _demo_expenses_desired x
+JOIN public.egresos e ON e.idempotency_key = x.key_value
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET tipo = EXCLUDED.tipo,
+    fecha = EXCLUDED.fecha,
+    importe = EXCLUDED.importe,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    pago_id = EXCLUDED.pago_id,
+    egreso_id = EXCLUDED.egreso_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_caja
+    (tipo, fecha, importe, metodo_pago_id, pago_id, egreso_id,
+     movimiento_revertido_id, usuario_id, idempotency_key, motivo, created_at)
+SELECT 'REVERSO',
+       (SELECT anchor_date FROM _demo_config),
+       original.importe,
+       original.metodo_pago_id,
+       NULL,
+       NULL,
+       original.id,
+       u.id,
+       'demo-seed:v1:caja:reversa-egreso:007',
+       '[DEMO:CAJA] Reversión del egreso anulado.',
+       (SELECT anchor_ts + interval '8 minutes' FROM _demo_config)
+FROM public.movimientos_caja original
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+WHERE original.idempotency_key = 'demo-seed:v1:caja:egreso:007'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET tipo = EXCLUDED.tipo,
+    fecha = EXCLUDED.fecha,
+    importe = EXCLUDED.importe,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    pago_id = EXCLUDED.pago_id,
+    egreso_id = EXCLUDED.egreso_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_caja
+    (tipo, fecha, importe, metodo_pago_id, pago_id, egreso_id,
+     movimiento_revertido_id, usuario_id, idempotency_key, motivo, created_at)
+SELECT CASE WHEN n <= 3 THEN 'AJUSTE_INGRESO' ELSE 'AJUSTE_EGRESO' END,
+       (SELECT anchor_date FROM _demo_config),
+       (1000 + n * 250)::numeric(19,2),
+       mp.id,
+       NULL,
+       NULL,
+       NULL,
+       u.id,
+       'demo-seed:v1:caja:ajuste:' || lpad(n::text, 3, '0'),
+       '[DEMO:CAJA] Ajuste manual ficticio.',
+       (SELECT anchor_ts FROM _demo_config) + (480 + n) * interval '1 second'
+FROM generate_series(1, 4) AS g(n)
+JOIN public.metodo_pagos mp ON mp.descripcion = 'DEMO · Efectivo'
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET tipo = EXCLUDED.tipo,
+    fecha = EXCLUDED.fecha,
+    importe = EXCLUDED.importe,
+    metodo_pago_id = EXCLUDED.metodo_pago_id,
+    pago_id = EXCLUDED.pago_id,
+    egreso_id = EXCLUDED.egreso_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+-- Libro de stock: cinco ingresos, seis ventas, dos ajustes y una reversión.
+INSERT INTO public.movimientos_stock
+    (stock_id, tipo, cantidad, venta_stock_id, movimiento_revertido_id,
+     usuario_id, idempotency_key, motivo, created_at)
+SELECT s.id,
+       'INGRESO',
+       20,
+       NULL,
+       NULL,
+       u.id,
+       'demo-seed:v1:stock:ingreso:' || lpad(x.seq::text, 3, '0'),
+       '[DEMO:STOCK] Existencia inicial.',
+       (SELECT anchor_ts FROM _demo_config) + (500 + x.seq) * interval '1 second'
+FROM _demo_stocks_desired x
+JOIN public.stocks s ON s.codigo_barras = x.barcode
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+WHERE x.seq <= 5
+ON CONFLICT (idempotency_key) DO UPDATE
+SET stock_id = EXCLUDED.stock_id,
+    tipo = EXCLUDED.tipo,
+    cantidad = EXCLUDED.cantidad,
+    venta_stock_id = EXCLUDED.venta_stock_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_stock
+    (stock_id, tipo, cantidad, venta_stock_id, movimiento_revertido_id,
+     usuario_id, idempotency_key, motivo, created_at)
+SELECT v.stock_id,
+       'VENTA',
+       v.cantidad,
+       v.id,
+       NULL,
+       u.id,
+       'demo-seed:v1:stock:venta:' || lpad(x.seq::text, 3, '0'),
+       NULL,
+       (SELECT anchor_ts FROM _demo_config) + (510 + x.seq) * interval '1 second'
+FROM _demo_stocks_desired x
+JOIN public.ventas_stock v ON v.idempotency_key = 'demo-seed:v1:venta:' || lpad(x.seq::text, 3, '0')
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET stock_id = EXCLUDED.stock_id,
+    tipo = EXCLUDED.tipo,
+    cantidad = EXCLUDED.cantidad,
+    venta_stock_id = EXCLUDED.venta_stock_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_stock
+    (stock_id, tipo, cantidad, venta_stock_id, movimiento_revertido_id,
+     usuario_id, idempotency_key, motivo, created_at)
+SELECT s.id,
+       adjustment.movement_type,
+       adjustment.quantity,
+       NULL,
+       NULL,
+       u.id,
+       adjustment.key_value,
+       adjustment.reason,
+       (SELECT anchor_ts FROM _demo_config) + adjustment.seq * interval '1 second'
+FROM (VALUES
+    (520, 'DEMO-STOCK-001', 'AJUSTE_POSITIVO', 2, 'demo-seed:v1:stock:ajuste-positivo:001', '[DEMO:STOCK] Ajuste positivo.'),
+    (521, 'DEMO-STOCK-002', 'AJUSTE_NEGATIVO', 1, 'demo-seed:v1:stock:ajuste-negativo:002', '[DEMO:STOCK] Ajuste negativo.')
+) AS adjustment(seq, barcode, movement_type, quantity, key_value, reason)
+JOIN public.stocks s ON s.codigo_barras = adjustment.barcode
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET stock_id = EXCLUDED.stock_id,
+    tipo = EXCLUDED.tipo,
+    cantidad = EXCLUDED.cantidad,
+    venta_stock_id = EXCLUDED.venta_stock_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO public.movimientos_stock
+    (stock_id, tipo, cantidad, venta_stock_id, movimiento_revertido_id,
+     usuario_id, idempotency_key, motivo, created_at)
+SELECT original.stock_id,
+       'REVERSO',
+       original.cantidad,
+       NULL,
+       original.id,
+       u.id,
+       'demo-seed:v1:stock:reversa-venta:006',
+       '[DEMO:STOCK] Restitución por venta anulada.',
+       (SELECT anchor_ts + interval '9 minutes' FROM _demo_config)
+FROM public.movimientos_stock original
+JOIN public.usuarios u ON lower(u.nombre_usuario) = 'demo-administrador'
+WHERE original.idempotency_key = 'demo-seed:v1:stock:venta:006'
+ON CONFLICT (idempotency_key) DO UPDATE
+SET stock_id = EXCLUDED.stock_id,
+    tipo = EXCLUDED.tipo,
+    cantidad = EXCLUDED.cantidad,
+    venta_stock_id = EXCLUDED.venta_stock_id,
+    movimiento_revertido_id = EXCLUDED.movimiento_revertido_id,
+    usuario_id = EXCLUDED.usuario_id,
+    motivo = EXCLUDED.motivo,
+    created_at = EXCLUDED.created_at;
+
+-- Recibos históricos y outbox técnica; no se crean archivos físicos.
+INSERT INTO public.recibos (pago_id, storage_key, generado_at, enviado_at)
+SELECT p.id,
+       'demo/recibos/pago-' || lpad(x.payment_no::text, 3, '0') || '.pdf',
+       (SELECT anchor_ts FROM _demo_config) + (600 + x.payment_no) * interval '1 second',
+       CASE WHEN x.payment_no % 4 = 0
+            THEN (SELECT anchor_ts FROM _demo_config) + (700 + x.payment_no) * interval '1 second'
+            ELSE NULL END
+FROM _demo_payments_desired x
+JOIN public.pagos p ON p.idempotency_key = x.idempotency_key
+ON CONFLICT (pago_id) DO UPDATE
+SET storage_key = EXCLUDED.storage_key,
+    generado_at = EXCLUDED.generado_at,
+    enviado_at = EXCLUDED.enviado_at;
+
+INSERT INTO public.recibos_pendientes
+    (pago_id, tipo, estado, intentos, next_attempt_at, idempotency_key,
+     claim_token, claimed_at, lease_until, ultimo_error, created_at, processed_at)
+SELECT p.id,
+       'GENERAR_Y_ENVIAR',
+       CASE WHEN x.payment_no % 4 = 0 THEN 'COMPLETADO' ELSE 'PENDIENTE' END,
+       CASE WHEN x.payment_no % 4 = 0 THEN 1 ELSE 0 END,
+       (SELECT anchor_ts FROM _demo_config) + interval '1 day',
+       'demo-seed:v1:recibo:' || lpad(x.payment_no::text, 3, '0'),
+       NULL,
+       NULL,
+       NULL,
+       NULL,
+       (SELECT anchor_ts FROM _demo_config) + (750 + x.payment_no) * interval '1 second',
+       CASE WHEN x.payment_no % 4 = 0
+            THEN (SELECT anchor_ts FROM _demo_config) + (800 + x.payment_no) * interval '1 second'
+            ELSE NULL END
+FROM _demo_payments_desired x
+JOIN public.pagos p ON p.idempotency_key = x.idempotency_key
+ON CONFLICT (pago_id, tipo) DO UPDATE
+SET estado = EXCLUDED.estado,
+    intentos = EXCLUDED.intentos,
+    next_attempt_at = EXCLUDED.next_attempt_at,
+    idempotency_key = EXCLUDED.idempotency_key,
+    claim_token = EXCLUDED.claim_token,
+    claimed_at = EXCLUDED.claimed_at,
+    lease_until = EXCLUDED.lease_until,
+    ultimo_error = EXCLUDED.ultimo_error,
+    created_at = EXCLUDED.created_at,
+    processed_at = EXCLUDED.processed_at;
+
+-- Validaciones internas antes de confirmar la transacción.
+DO $$
+DECLARE
+    actual_counts jsonb;
+    expected_counts jsonb;
+    direct_total integer;
+    registered_payments numeric(19,2);
+    active_applications numeric(19,2);
+    active_payment_credit numeric(19,2);
+    net_credit numeric(19,2);
+BEGIN
+    SELECT jsonb_build_object(
+        'usuarios', (SELECT count(*) FROM public.usuarios WHERE lower(nombre_usuario) LIKE 'demo-%'),
+        'usuario_roles', (SELECT count(*) FROM public.usuario_roles ur JOIN public.usuarios u ON u.id = ur.usuario_id WHERE lower(u.nombre_usuario) LIKE 'demo-%'),
+        'salones', (SELECT count(*) FROM public.salones WHERE nombre LIKE 'DEMO · %'),
+        'profesores', (SELECT count(*) FROM public.profesores WHERE nombre LIKE 'DEMO · Profesor %'),
+        'observaciones_profesores', (SELECT count(*) FROM public.observaciones_profesores op JOIN public.profesores p ON p.id = op.profesor_id WHERE p.nombre LIKE 'DEMO · Profesor %'),
+        'bonificaciones', (SELECT count(*) FROM public.bonificaciones WHERE descripcion LIKE 'DEMO · %'),
+        'recargos', (SELECT count(*) FROM public.recargos WHERE descripcion LIKE 'DEMO · %'),
+        'metodo_pagos', (SELECT count(*) FROM public.metodo_pagos WHERE descripcion LIKE 'DEMO · %'),
+        'sub_conceptos', (SELECT count(*) FROM public.sub_conceptos WHERE descripcion LIKE 'DEMO · %'),
+        'conceptos', (SELECT count(*) FROM public.conceptos WHERE descripcion LIKE 'DEMO · %'),
+        'stocks', (SELECT count(*) FROM public.stocks WHERE codigo_barras LIKE 'DEMO-STOCK-%'),
+        'disciplinas', (SELECT count(*) FROM public.disciplinas WHERE nombre LIKE 'DEMO · %'),
+        'disciplina_horarios', (
+            SELECT count(*) FROM public.disciplina_horarios h
+            JOIN public.disciplinas d ON d.id = h.disciplina_id WHERE d.nombre LIKE 'DEMO · %'
+        ),
+        'alumnos', (SELECT count(*) FROM public.alumnos WHERE documento LIKE 'DEMO-DNI-%'),
+        'inscripciones', (
+            SELECT count(*) FROM public.inscripciones i
+            JOIN public.alumnos a ON a.id = i.alumno_id WHERE a.documento LIKE 'DEMO-DNI-%'
+        ),
+        'disciplina_tarifas', (
+            SELECT count(*) FROM public.disciplina_tarifas t
+            JOIN public.disciplinas d ON d.id = t.disciplina_id WHERE d.nombre LIKE 'DEMO · %'
+        ),
+        'inscripcion_condiciones_economicas', (
+            SELECT count(*) FROM public.inscripcion_condiciones_economicas c
+            JOIN public.inscripciones i ON i.id = c.inscripcion_id
+            JOIN public.alumnos a ON a.id = i.alumno_id WHERE a.documento LIKE 'DEMO-DNI-%'
+        ),
+        'mensualidades', (
+            SELECT count(*) FROM public.mensualidades m
+            JOIN public.inscripciones i ON i.id = m.inscripcion_id
+            JOIN public.alumnos a ON a.id = i.alumno_id WHERE a.documento LIKE 'DEMO-DNI-%'
+        ),
+        'matriculas', (
+            SELECT count(*) FROM public.matriculas m
+            JOIN public.alumnos a ON a.id = m.alumno_id WHERE a.documento LIKE 'DEMO-DNI-%'
+        ),
+        'asistencias_mensuales', (
+            SELECT count(*) FROM public.asistencias_mensuales am
+            JOIN public.disciplinas d ON d.id = am.disciplina_id WHERE d.nombre LIKE 'DEMO · %'
+        ),
+        'asistencias_alumno_mensual', (
+            SELECT count(*) FROM public.asistencias_alumno_mensual aam
+            JOIN public.inscripciones i ON i.id = aam.inscripcion_id
+            JOIN public.alumnos a ON a.id = i.alumno_id WHERE a.documento LIKE 'DEMO-DNI-%'
+        ),
+        'asistencias_diarias', (
+            SELECT count(*) FROM public.asistencias_diarias ad
+            JOIN public.asistencias_alumno_mensual aam ON aam.id = ad.asistencia_alumno_mensual_id
+            JOIN public.inscripciones i ON i.id = aam.inscripcion_id
+            JOIN public.alumnos a ON a.id = i.alumno_id WHERE a.documento LIKE 'DEMO-DNI-%'
+        ),
+        'ventas_stock', (SELECT count(*) FROM public.ventas_stock WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'cargos', (SELECT count(*) FROM public.cargos WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'cargo_liquidaciones', (
+            SELECT count(*) FROM public.cargo_liquidaciones cl
+            JOIN public.cargos c ON c.id = cl.cargo_id WHERE c.idempotency_key LIKE 'demo-seed:v1:%'
+        ),
+        'pagos', (SELECT count(*) FROM public.pagos WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'aplicaciones_pago', (
+            SELECT count(*) FROM public.aplicaciones_pago ap
+            JOIN public.pagos p ON p.id = ap.pago_id WHERE p.idempotency_key LIKE 'demo-seed:v1:%'
+        ),
+        'egresos', (SELECT count(*) FROM public.egresos WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'movimientos_caja', (SELECT count(*) FROM public.movimientos_caja WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'movimientos_credito', (SELECT count(*) FROM public.movimientos_credito WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'movimientos_stock', (SELECT count(*) FROM public.movimientos_stock WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+        'recibos', (
+            SELECT count(*) FROM public.recibos r
+            JOIN public.pagos p ON p.id = r.pago_id WHERE p.idempotency_key LIKE 'demo-seed:v1:%'
+        ),
+        'recibos_pendientes', (
+            SELECT count(*) FROM public.recibos_pendientes rp
+            JOIN public.pagos p ON p.id = rp.pago_id WHERE p.idempotency_key LIKE 'demo-seed:v1:%'
+        )
+    ) INTO actual_counts;
+
+    expected_counts := jsonb_build_object(
+        'usuarios', 5, 'usuario_roles', 5, 'salones', 3, 'profesores', 6,
+        'observaciones_profesores', 6, 'bonificaciones', 4, 'recargos', 3,
+        'metodo_pagos', 4, 'sub_conceptos', 4, 'conceptos', 8, 'stocks', 6,
+        'disciplinas', 6, 'disciplina_horarios', 11, 'alumnos', 28,
+        'inscripciones', 34, 'disciplina_tarifas', 12,
+        'inscripcion_condiciones_economicas', 40, 'mensualidades', 70,
+        'matriculas', 26, 'asistencias_mensuales', 6,
+        'asistencias_alumno_mensual', 18, 'asistencias_diarias', 54,
+        'ventas_stock', 6, 'cargos', 115, 'cargo_liquidaciones', 115,
+        'pagos', 48, 'aplicaciones_pago', 82, 'egresos', 7,
+        'movimientos_caja', 61, 'movimientos_credito', 11,
+        'movimientos_stock', 14, 'recibos', 48, 'recibos_pendientes', 48
+    );
+
+    IF actual_counts <> expected_counts THEN
+        RAISE EXCEPTION 'Conteos demo inesperados. Esperado=%, actual=%', expected_counts, actual_counts;
+    END IF;
+
+    SELECT sum(value::integer) INTO direct_total FROM jsonb_each_text(actual_counts);
+    IF direct_total <> 914 THEN
+        RAISE EXCEPTION 'El total de filas gestionadas directamente debe ser 914 y fue %', direct_total;
+    END IF;
+
+    SELECT COALESCE(sum(p.monto_recibido), 0)
+    INTO registered_payments
+    FROM public.pagos p
+    WHERE p.idempotency_key LIKE 'demo-seed:v1:%' AND p.estado = 'REGISTRADO';
+
+    SELECT COALESCE(sum(ap.importe_aplicado), 0)
+    INTO active_applications
+    FROM public.aplicaciones_pago ap
+    JOIN public.pagos p ON p.id = ap.pago_id
+    WHERE p.idempotency_key LIKE 'demo-seed:v1:%' AND ap.estado = 'APLICADA';
+
+    SELECT COALESCE(sum(CASE mc.tipo WHEN 'GENERACION' THEN mc.importe
+                                     WHEN 'REVERSO' THEN -mc.importe ELSE 0 END), 0)
+    INTO active_payment_credit
+    FROM public.movimientos_credito mc
+    WHERE mc.idempotency_key LIKE 'demo-seed:v1:%'
+      AND (mc.pago_id IS NOT NULL OR mc.idempotency_key LIKE 'demo-seed:v1:credito:reversa-generacion%');
+
+    SELECT COALESCE(sum(CASE mc.tipo
+        WHEN 'GENERACION' THEN mc.importe
+        WHEN 'AJUSTE_CREDITO' THEN mc.importe
+        WHEN 'CONSUMO' THEN -mc.importe
+        WHEN 'AJUSTE_DEBITO' THEN -mc.importe
+        WHEN 'REVERSO' THEN CASE WHEN original.tipo = 'CONSUMO' THEN mc.importe ELSE -mc.importe END
+        ELSE 0 END), 0)
+    INTO net_credit
+    FROM public.movimientos_credito mc
+    LEFT JOIN public.movimientos_credito original ON original.id = mc.movimiento_revertido_id
+    WHERE mc.idempotency_key LIKE 'demo-seed:v1:%';
+
+    IF registered_payments <> 1956700.00
+       OR active_applications <> 1938700.00
+       OR active_payment_credit <> 18000.00
+       OR net_credit <> 21000.00
+       OR registered_payments <> active_applications + active_payment_credit THEN
+        RAISE EXCEPTION 'Conciliación financiera inesperada: pagos=%, aplicaciones=%, crédito de pagos=%, crédito neto=%',
+            registered_payments, active_applications, active_payment_credit, net_credit;
+    END IF;
+
+    IF EXISTS (
+        WITH applications AS (
+            SELECT pago_id, sum(importe_aplicado) AS amount
+            FROM public.aplicaciones_pago WHERE estado = 'APLICADA' GROUP BY pago_id
+        ), generated_credit AS (
+            SELECT pago_id, sum(importe) AS amount
+            FROM public.movimientos_credito WHERE tipo = 'GENERACION' GROUP BY pago_id
+        )
+        SELECT 1
+        FROM public.pagos p
+        LEFT JOIN applications ap ON ap.pago_id = p.id
+        LEFT JOIN generated_credit mc ON mc.pago_id = p.id
+        WHERE p.idempotency_key LIKE 'demo-seed:v1:%'
+          AND p.estado = 'REGISTRADO'
+          AND p.monto_recibido <> COALESCE(ap.amount, 0) + COALESCE(mc.amount, 0)
+    ) THEN
+        RAISE EXCEPTION 'Existe un pago registrado no conciliado con aplicaciones y crédito';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.pagos p
+        JOIN public.aplicaciones_pago ap ON ap.pago_id = p.id
+        WHERE p.idempotency_key = 'demo-seed:v1:pago:048'
+          AND (p.estado <> 'ANULADO' OR ap.estado <> 'REVERTIDA')
+    ) THEN
+        RAISE EXCEPTION 'El escenario de pago anulado no quedó completamente revertido';
+    END IF;
+
+    IF EXISTS (
+        WITH paid AS (
+            SELECT cargo_id, sum(importe_aplicado) AS amount
+            FROM public.aplicaciones_pago WHERE estado = 'APLICADA' GROUP BY cargo_id
+        ), credit AS (
+            SELECT cargo_id, sum(amount) AS amount
+            FROM (
+                SELECT cargo_id, importe AS amount
+                FROM public.movimientos_credito WHERE tipo = 'CONSUMO'
+                UNION ALL
+                SELECT original.cargo_id, -reversal.importe
+                FROM public.movimientos_credito reversal
+                JOIN public.movimientos_credito original ON original.id = reversal.movimiento_revertido_id
+                WHERE reversal.tipo = 'REVERSO' AND original.tipo = 'CONSUMO'
+            ) movements GROUP BY cargo_id
+        )
+        SELECT 1
+        FROM public.cargos c
+        JOIN public.alumnos a ON a.id = c.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+        LEFT JOIN paid ON paid.cargo_id = c.id
+        LEFT JOIN credit ON credit.cargo_id = c.id
+        WHERE COALESCE(paid.amount, 0) + COALESCE(credit.amount, 0) > c.importe_original
+           OR c.estado <> CASE
+                WHEN c.estado = 'ANULADO' THEN 'ANULADO'
+                WHEN c.importe_original - COALESCE(paid.amount, 0) - COALESCE(credit.amount, 0) = 0 THEN 'PAGADO'
+                WHEN c.importe_original - COALESCE(paid.amount, 0) - COALESCE(credit.amount, 0) < c.importe_original THEN 'PARCIAL'
+                ELSE 'PENDIENTE' END
+    ) THEN
+        RAISE EXCEPTION 'Existen saldos o estados de cargo incoherentes';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.cargo_liquidaciones cl
+        JOIN public.cargos c ON c.id = cl.cargo_id AND c.idempotency_key LIKE 'demo-seed:v1:%'
+        WHERE cl.importe_final <> cl.importe_base - cl.descuento_importe + cl.recargo_importe
+           OR cl.importe_final <> c.importe_original
+    ) THEN
+        RAISE EXCEPTION 'Las liquidaciones demo no concilian con sus cargos';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT mc.alumno_id,
+                   sum(CASE mc.tipo
+                       WHEN 'GENERACION' THEN mc.importe
+                       WHEN 'AJUSTE_CREDITO' THEN mc.importe
+                       WHEN 'CONSUMO' THEN -mc.importe
+                       WHEN 'AJUSTE_DEBITO' THEN -mc.importe
+                       WHEN 'REVERSO' THEN CASE WHEN original.tipo = 'CONSUMO' THEN mc.importe ELSE -mc.importe END
+                       ELSE 0 END) AS balance
+            FROM public.movimientos_credito mc
+            LEFT JOIN public.movimientos_credito original ON original.id = mc.movimiento_revertido_id
+            WHERE mc.idempotency_key LIKE 'demo-seed:v1:%'
+            GROUP BY mc.alumno_id
+        ) balances
+        WHERE balances.balance < 0
+    ) THEN
+        RAISE EXCEPTION 'Existe un saldo de crédito demo negativo';
+    END IF;
+
+    IF EXISTS (
+        WITH book AS (
+            SELECT ms.stock_id,
+                   sum(CASE ms.tipo WHEN 'INGRESO' THEN ms.cantidad
+                                    WHEN 'AJUSTE_POSITIVO' THEN ms.cantidad
+                                    WHEN 'REVERSO' THEN ms.cantidad
+                                    WHEN 'VENTA' THEN -ms.cantidad
+                                    WHEN 'AJUSTE_NEGATIVO' THEN -ms.cantidad ELSE 0 END) AS quantity
+            FROM public.movimientos_stock ms
+            WHERE ms.idempotency_key LIKE 'demo-seed:v1:%'
+            GROUP BY ms.stock_id
+        )
+        SELECT 1
+        FROM public.stocks s
+        JOIN book ON book.stock_id = s.id
+        WHERE s.codigo_barras LIKE 'DEMO-STOCK-%'
+          AND s.requiere_control_de_stock
+          AND (s.cantidad_actual < 0 OR s.cantidad_actual <> book.quantity)
+    ) THEN
+        RAISE EXCEPTION 'El stock materializado no coincide con el libro demo';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.ventas_stock v
+        LEFT JOIN public.cargos c ON c.venta_stock_id = v.id
+        LEFT JOIN public.movimientos_stock original ON original.venta_stock_id = v.id AND original.tipo = 'VENTA'
+        LEFT JOIN public.movimientos_stock reversal ON reversal.movimiento_revertido_id = original.id AND reversal.tipo = 'REVERSO'
+        WHERE v.idempotency_key LIKE 'demo-seed:v1:%'
+          AND (c.id IS NULL OR original.id IS NULL
+               OR (v.estado = 'REGISTRADA' AND (c.estado = 'ANULADO' OR reversal.id IS NOT NULL))
+               OR (v.estado = 'ANULADA' AND (c.estado <> 'ANULADO' OR reversal.id IS NULL)))
+    ) THEN
+        RAISE EXCEPTION 'Las ventas demo no concilian con cargo y libro de stock';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.usuarios u
+        JOIN public.usuario_roles ur ON ur.usuario_id = u.id
+        JOIN public.roles r ON r.id = ur.rol_id
+        WHERE lower(u.nombre_usuario) LIKE 'demo-%'
+          AND (NOT r.activo OR r.codigo = 'PROFESOR' OR u.rol_id <> ur.rol_id)
+    ) THEN
+        RAISE EXCEPTION 'Las identidades demo tienen roles inactivos, diferidos o desincronizados';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM (
+            SELECT movimiento_revertido_id FROM public.movimientos_caja
+            WHERE idempotency_key LIKE 'demo-seed:v1:%' AND movimiento_revertido_id IS NOT NULL
+            GROUP BY movimiento_revertido_id HAVING count(*) > 1
+            UNION ALL
+            SELECT movimiento_revertido_id FROM public.movimientos_credito
+            WHERE idempotency_key LIKE 'demo-seed:v1:%' AND movimiento_revertido_id IS NOT NULL
+            GROUP BY movimiento_revertido_id HAVING count(*) > 1
+            UNION ALL
+            SELECT movimiento_revertido_id FROM public.movimientos_stock
+            WHERE idempotency_key LIKE 'demo-seed:v1:%' AND movimiento_revertido_id IS NOT NULL
+            GROUP BY movimiento_revertido_id HAVING count(*) > 1
+        ) duplicates
+    ) THEN
+        RAISE EXCEPTION 'Existe más de una reversión para una operación original';
+    END IF;
+
+    IF (SELECT count(*) FROM public.roles) <> (SELECT roles_count FROM _demo_guard)
+       OR (SELECT md5(COALESCE(string_agg(
+            r.id::text || '|' || r.codigo || '|' || r.activo::text || '|' || r.sistema::text || '|' || r.editable::text,
+            E'\n' ORDER BY r.id), '')) FROM public.roles r) <> (SELECT roles_hash FROM _demo_guard)
+       OR (SELECT count(*) FROM public.permisos) <> (SELECT permissions_count FROM _demo_guard)
+       OR (SELECT md5(COALESCE(string_agg(
+            p.id::text || '|' || p.codigo || '|' || p.activo::text || '|' || p.sistema::text || '|' || p.modulo || '|' || p.descripcion,
+            E'\n' ORDER BY p.id), '')) FROM public.permisos p) <> (SELECT permissions_hash FROM _demo_guard)
+       OR (SELECT count(*) FROM public.rol_permisos) <> (SELECT matrix_count FROM _demo_guard)
+       OR (SELECT md5(COALESCE(string_agg(
+            rp.rol_id::text || '|' || rp.permiso_id::text,
+            E'\n' ORDER BY rp.rol_id, rp.permiso_id), '')) FROM public.rol_permisos rp) <> (SELECT matrix_hash FROM _demo_guard) THEN
+        RAISE EXCEPTION 'El catálogo o la matriz RBAC cambió durante el seed';
+    END IF;
+
+    IF (SELECT count(*) FROM public.usuarios u WHERE lower(u.nombre_usuario) NOT LIKE 'demo-%') <>
+           (SELECT other_users_count FROM _demo_guard)
+       OR (SELECT md5(COALESCE(string_agg(to_jsonb(u)::text, E'\n' ORDER BY u.id), ''))
+           FROM public.usuarios u WHERE lower(u.nombre_usuario) NOT LIKE 'demo-%') <>
+           (SELECT other_users_hash FROM _demo_guard) THEN
+        RAISE EXCEPTION 'El seed modificó usuarios ajenos al namespace demo';
+    END IF;
+
+    IF (SELECT count(*) FROM public.refresh_sessions) <> (SELECT refresh_count FROM _demo_guard)
+       OR (SELECT count(*) FROM public.bootstrap_ejecuciones) <> (SELECT bootstrap_count FROM _demo_guard)
+       OR (SELECT count(*) FROM public.auditoria_eventos) <> (SELECT audit_count FROM _demo_guard)
+       OR (SELECT count(*) FROM public.cargo_eventos) <> (SELECT charge_events_count FROM _demo_guard)
+       OR (SELECT count(*) FROM public.notificaciones) <> (SELECT notifications_count FROM _demo_guard) THEN
+        RAISE EXCEPTION 'El SQL pobló una tabla derivada reservada a servicios productivos';
+    END IF;
+
+    RAISE NOTICE 'Seed demo validado: 914 filas, RBAC intacto y libros conciliados.';
+END
+$$;
 
 COMMIT;
 
--- Validación rápida sugerida:
--- SELECT 'roles' AS tabla, count(*) FROM public.roles
--- UNION ALL SELECT 'usuarios', count(*) FROM public.usuarios
--- UNION ALL SELECT 'permisos', count(*) FROM public.permisos
--- UNION ALL SELECT 'alumnos', count(*) FROM public.alumnos
--- UNION ALL SELECT 'cargos', count(*) FROM public.cargos
--- UNION ALL SELECT 'pagos', count(*) FROM public.pagos
--- UNION ALL SELECT 'egresos', count(*) FROM public.egresos
--- UNION ALL SELECT 'movimientos_caja', count(*) FROM public.movimientos_caja
--- UNION ALL SELECT 'movimientos_credito', count(*) FROM public.movimientos_credito
--- UNION ALL SELECT 'movimientos_stock', count(*) FROM public.movimientos_stock;
+\echo GESTUDIO DEMO SEED: ejecución completada y validada

--- a/scripts/validate-demo-seed.ps1
+++ b/scripts/validate-demo-seed.ps1
@@ -1,0 +1,1560 @@
+param(
+    [switch] $SkipBackendBuild,
+    [switch] $VerboseHttp
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Add-Type -AssemblyName System.Net.Http
+
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$backendRoot = Join-Path $repoRoot "backend"
+$composeFile = Join-Path $repoRoot "docker-compose.yml"
+$seedPath = Join-Path $repoRoot "scripts/gestudio_demo_seed_full.sql"
+$migrationRoot = Join-Path $backendRoot "src/main/resources/db/migration"
+$startedAt = Get-Date
+$deadline = $startedAt.AddMinutes(35)
+$suffix = ([Guid]::NewGuid().ToString("N")).Substring(0, 10)
+$project = "gestudio-demo-seed-$PID-$suffix"
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) $project
+$receiptsRoot = Join-Path $tempRoot "receipts"
+$backendStdout = Join-Path $tempRoot "backend.stdout.log"
+$backendStderr = Join-Path $tempRoot "backend.stderr.log"
+$results = [Collections.Generic.List[object]]::new()
+$secretValues = [Collections.Generic.List[string]]::new()
+$originalEnvironment = @{}
+$backendProcess = $null
+$stackAttempted = $false
+$http = $null
+$cookieContainer = $null
+$exitCode = 0
+$caughtMessage = $null
+$isWindowsHost = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
+
+$dbPort = $null
+$backendPort = $null
+$postgresDb = "gestudio_demo_$suffix"
+$postgresUser = "gestudio_demo_$suffix"
+$postgresPassword = $null
+$jwtSecret = $null
+$anchorDate = $null
+$apiBase = $null
+$frontendOrigin = $null
+$javaHome = $null
+$javaExe = $null
+$javacExe = $null
+$mavenWrapper = $null
+$backendJar = $null
+$bcryptClasspath = $null
+$demoPasswords = @{}
+$demoHashes = @{}
+$actorTokens = @{}
+
+function Add-Result {
+    param(
+        [Parameter(Mandatory)][string] $Stage,
+        [Parameter(Mandatory)][ValidateSet("PASS", "FAIL", "INFO")][string] $Result,
+        [Parameter(Mandatory)][string] $Detail
+    )
+
+    $script:results.Add([pscustomobject]@{
+        Etapa = $Stage
+        Resultado = $Result
+        Detalle = $Detail
+    })
+
+    $color = switch ($Result) {
+        "PASS" { "Green" }
+        "FAIL" { "Red" }
+        default { "Cyan" }
+    }
+    Write-Host "[$Result] $Stage - $Detail" -ForegroundColor $color
+}
+
+function Add-Secret {
+    param([AllowNull()][string] $Value)
+
+    if (-not [string]::IsNullOrEmpty($Value) -and -not $script:secretValues.Contains($Value)) {
+        $script:secretValues.Add($Value)
+    }
+}
+
+function Redact {
+    param([AllowNull()][string] $Text)
+
+    if ($null -eq $Text) { return "" }
+    $safe = $Text
+    foreach ($secret in $script:secretValues) {
+        if (-not [string]::IsNullOrEmpty($secret)) {
+            $safe = $safe.Replace($secret, "<redacted>")
+        }
+    }
+    return $safe
+}
+
+function Assert-Deadline {
+    if ((Get-Date) -gt $script:deadline) {
+        throw "Se agotó el timeout global de 35 minutos"
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)][bool] $Condition,
+        [Parameter(Mandatory)][string] $Message
+    )
+
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param(
+        $Actual,
+        $Expected,
+        [Parameter(Mandatory)][string] $Message
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "$Message (esperado=$Expected, actual=$Actual)"
+    }
+}
+
+function New-HexSecret {
+    param([Parameter(Mandatory)][int] $Bytes)
+
+    $buffer = New-Object byte[] $Bytes
+    $rng = [Security.Cryptography.RandomNumberGenerator]::Create()
+    try { $rng.GetBytes($buffer) }
+    finally { $rng.Dispose() }
+    return [BitConverter]::ToString($buffer).Replace("-", "").ToLowerInvariant()
+}
+
+function Get-FreePort {
+    $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+    try {
+        $listener.Start()
+        return ([Net.IPEndPoint]$listener.LocalEndpoint).Port
+    }
+    finally { $listener.Stop() }
+}
+
+function Get-BusinessDate {
+    try {
+        $zone = [TimeZoneInfo]::FindSystemTimeZoneById("America/Argentina/Buenos_Aires")
+    }
+    catch {
+        $zone = [TimeZoneInfo]::FindSystemTimeZoneById("Argentina Standard Time")
+    }
+
+    return [TimeZoneInfo]::ConvertTime([DateTimeOffset]::UtcNow, $zone).Date
+}
+
+function Set-ScopedEnvironmentVariable {
+    param(
+        [Parameter(Mandatory)][string] $Name,
+        [AllowNull()][string] $Value
+    )
+
+    if (-not $script:originalEnvironment.ContainsKey($Name)) {
+        $script:originalEnvironment[$Name] = [Environment]::GetEnvironmentVariable($Name, "Process")
+    }
+    [Environment]::SetEnvironmentVariable($Name, $Value, "Process")
+}
+
+function Restore-Environment {
+    foreach ($entry in $script:originalEnvironment.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "Process")
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory)][string] $FilePath,
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [switch] $Capture,
+        [switch] $IgnoreDeadline
+    )
+
+    if (-not $IgnoreDeadline) { Assert-Deadline }
+    $previousErrorAction = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = @(& $FilePath @Arguments 2>&1)
+        $code = $LASTEXITCODE
+    }
+    finally { $ErrorActionPreference = $previousErrorAction }
+
+    $text = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+    if ($code -ne 0) {
+        $tail = (($text -split "`r?`n") | Select-Object -Last 80) -join "`n"
+        throw "El comando $([IO.Path]::GetFileName($FilePath)) falló con código ${code}: $(Redact $tail)"
+    }
+
+    if ($Capture) { return $text.Trim() }
+    if (-not [string]::IsNullOrWhiteSpace($text)) { Write-Host (Redact $text) }
+}
+
+function Invoke-Docker {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [switch] $Capture,
+        [switch] $IgnoreDeadline
+    )
+
+    return Invoke-Native -FilePath "docker" -Arguments $Arguments -Capture:$Capture -IgnoreDeadline:$IgnoreDeadline
+}
+
+function Invoke-Compose {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [switch] $Capture,
+        [switch] $IgnoreDeadline
+    )
+
+    $all = @("compose", "-f", $script:composeFile, "-p", $script:project) + $Arguments
+    return Invoke-Docker -Arguments $all -Capture:$Capture -IgnoreDeadline:$IgnoreDeadline
+}
+
+function Wait-DatabaseHealthy {
+    while ((Get-Date) -lt $script:deadline) {
+        $containerId = Invoke-Compose -Arguments @("ps", "-q", "db") -Capture
+        if (-not [string]::IsNullOrWhiteSpace($containerId)) {
+            $state = Invoke-Docker -Arguments @(
+                "inspect", "--format",
+                "{{.State.Status}}|{{if .State.Health}}{{.State.Health.Status}}{{end}}",
+                $containerId
+            ) -Capture
+            if ($state -eq "running|healthy") { return }
+            if ($state.StartsWith("exited|") -or $state.StartsWith("dead|")) {
+                throw "PostgreSQL terminó antes de estar healthy"
+            }
+        }
+        Start-Sleep -Seconds 2
+    }
+    throw "Timeout esperando PostgreSQL healthy"
+}
+
+function Invoke-Sql {
+    param([Parameter(Mandatory)][string] $Query)
+
+    Assert-Deadline
+    $arguments = @(
+        "compose", "-f", $script:composeFile, "-p", $script:project,
+        "exec", "-T", "db", "psql",
+        "-v", "ON_ERROR_STOP=1",
+        "-U", $script:postgresUser,
+        "-d", $script:postgresDb,
+        "-A", "-t", "-F", "|",
+        "-c", $Query
+    )
+
+    $previousErrorAction = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = @(& docker @arguments 2>&1)
+        $code = $LASTEXITCODE
+    }
+    finally { $ErrorActionPreference = $previousErrorAction }
+
+    $text = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+    if ($code -ne 0) {
+        throw "La consulta SQL falló: $(Redact $text)"
+    }
+    return $text.Trim()
+}
+
+function Assert-SqlZero {
+    param(
+        [Parameter(Mandatory)][string] $Stage,
+        [Parameter(Mandatory)][string] $Query
+    )
+
+    $actual = Invoke-Sql -Query $Query
+    Assert-Equal -Actual $actual -Expected "0" -Message "Falló la regla de integridad: $Stage"
+    Add-Result -Stage $Stage -Result "PASS" -Detail "0 inconsistencias"
+}
+
+function Assert-SeedStaticContract {
+    $seed = [IO.File]::ReadAllText($script:seedPath)
+
+    foreach ($requiredText in @(
+        "ESTE ARCHIVO NO ES UNA MIGRACIÓN FLYWAY",
+        "\set ON_ERROR_STOP on",
+        "BEGIN;",
+        "COMMIT;"
+    )) {
+        if (-not $seed.Contains($requiredText)) {
+            throw "El seed no contiene el contrato obligatorio: $requiredText"
+        }
+    }
+
+    $forbiddenPatterns = [ordered]@{
+        '(?im)^\s*(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(?:public\.)?(roles|permisos|rol_permisos)\b' = "El seed intenta modificar el RBAC productivo"
+        '(?im)^\s*(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(?:public\.)?(refresh_sessions|bootstrap_ejecuciones|auditoria_eventos|cargo_eventos|notificaciones)\b' = "El seed intenta poblar tablas derivadas de servicios productivos"
+        '(?im)^\s*TRUNCATE\b' = "El seed contiene TRUNCATE"
+        '(?im)^\s*ALTER\s+TABLE\b' = "El seed intenta alterar el esquema"
+        '(?im)^\s*DROP\s+SCHEMA\b' = "El seed intenta eliminar un esquema"
+        '(?im)^\s*SET\s+session_replication_role\b' = "El seed intenta desactivar integridad referencial"
+        '(?im)^\s*ALTER\s+TABLE\b.*DISABLE\s+TRIGGER\b' = "El seed intenta desactivar triggers"
+        '(?i)admin[/]admin' = "El seed contiene una credencial conocida"
+        '(?i)V6__.*demo.*seed|V6__.*seed.*demo' = "El seed se presenta como una migración V6 demo"
+        '(?<!\\)\$2[aby]\$[0-9]{2}\$[./A-Za-z0-9]{53}' = "El seed contiene un hash BCrypt fijo"
+    }
+
+    foreach ($entry in $forbiddenPatterns.GetEnumerator()) {
+        if ([regex]::IsMatch($seed, $entry.Key)) {
+            throw [string]$entry.Value
+        }
+    }
+
+    Add-Result -Stage "Contrato estático del seed" -Result "PASS" -Detail "Manual, transaccional, sin DML RBAC, secretos ni operaciones destructivas"
+}
+
+function Test-ByteSequence {
+    param(
+        [Parameter(Mandatory)][byte[]] $Haystack,
+        [Parameter(Mandatory)][byte[]] $Needle
+    )
+
+    if ($Needle.Length -eq 0 -or $Haystack.Length -lt $Needle.Length) { return $false }
+    $last = $Haystack.Length - $Needle.Length
+    for ($offset = 0; $offset -le $last; $offset++) {
+        if ($Haystack[$offset] -ne $Needle[0]) { continue }
+        $matches = $true
+        for ($index = 1; $index -lt $Needle.Length; $index++) {
+            if ($Haystack[$offset + $index] -ne $Needle[$index]) {
+                $matches = $false
+                break
+            }
+        }
+        if ($matches) { return $true }
+    }
+    return $false
+}
+
+function Assert-NoSecretsInTemporaryFiles {
+    foreach ($file in @(Get-ChildItem -LiteralPath $script:tempRoot -File -Recurse -ErrorAction SilentlyContinue)) {
+        if ($file.Length -gt 20MB) {
+            throw "No se puede auditar un temporal mayor a 20 MB: $($file.FullName)"
+        }
+        $bytes = [IO.File]::ReadAllBytes($file.FullName)
+        if ($bytes.Length -eq 0) { continue }
+        foreach ($secret in $script:secretValues) {
+            if ([string]::IsNullOrEmpty($secret)) { continue }
+            $needle = [Text.Encoding]::UTF8.GetBytes($secret)
+            if (Test-ByteSequence -Haystack $bytes -Needle $needle) {
+                throw "Se detectó un secreto efímero persistido en $($file.FullName)"
+            }
+        }
+    }
+    Add-Result -Stage "Persistencia de secretos" -Result "PASS" -Detail "Ninguna password, hash, token o secreto aparece en temporales"
+}
+
+function Invoke-DemoSeed {
+    Assert-Deadline
+    $containerId = Invoke-Compose -Arguments @("ps", "-q", "db") -Capture
+    if ([string]::IsNullOrWhiteSpace($containerId)) {
+        throw "No se pudo resolver el contenedor PostgreSQL aislado"
+    }
+
+    $containerSeedPath = "/tmp/gestudio_demo_seed_full.sql"
+    Invoke-Docker -Arguments @("cp", $script:seedPath, "${containerId}:$containerSeedPath") | Out-Null
+    try {
+        $arguments = @(
+            "compose", "-f", $script:composeFile, "-p", $script:project,
+            "exec", "-T", "db", "psql",
+            "-v", "ON_ERROR_STOP=1",
+            "-U", $script:postgresUser,
+            "-d", $script:postgresDb,
+            "-v", "demo_anchor_date=$($script:anchorDate.ToString('yyyy-MM-dd'))",
+            "-v", "demo_superadmin_password_hash=$($script:demoHashes['demo-superadmin'])",
+            "-v", "demo_direccion_password_hash=$($script:demoHashes['demo-direccion'])",
+            "-v", "demo_administrador_password_hash=$($script:demoHashes['demo-administrador'])",
+            "-v", "demo_secretaria_password_hash=$($script:demoHashes['demo-secretaria'])",
+            "-v", "demo_caja_password_hash=$($script:demoHashes['demo-caja'])",
+            "-f", $containerSeedPath
+        )
+
+        $previousErrorAction = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = "Continue"
+            $output = @(& docker @arguments 2>&1)
+            $code = $LASTEXITCODE
+        }
+        finally { $ErrorActionPreference = $previousErrorAction }
+
+        $text = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+        if ($code -ne 0) {
+            throw "El seed demo falló con código ${code}: $(Redact $text)"
+        }
+        if ($text -notmatch "GESTUDIO DEMO SEED: ejecución completada y validada") {
+            throw "El seed terminó sin emitir su confirmación canónica"
+        }
+        return $text.Trim()
+    }
+    finally {
+        try { Invoke-Docker -Arguments @("exec", $containerId, "rm", "-f", $containerSeedPath) | Out-Null }
+        catch { }
+    }
+}
+
+function Test-Java21Executable {
+    param([Parameter(Mandatory)][string] $Candidate)
+
+    if (-not (Test-Path -LiteralPath $Candidate -PathType Leaf)) { return $false }
+    $previousErrorAction = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = @(& $Candidate -version 2>&1)
+        $code = $LASTEXITCODE
+    }
+    finally { $ErrorActionPreference = $previousErrorAction }
+    if ($code -ne 0) { return $false }
+    $text = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+    return $text -match 'version\s+"21(?:\.|\")'
+}
+
+function Resolve-Java21 {
+    $javaName = if ($script:isWindowsHost) { "java.exe" } else { "java" }
+    $candidates = [Collections.Generic.List[string]]::new()
+
+    if (-not [string]::IsNullOrWhiteSpace($env:JAVA_HOME)) {
+        $candidates.Add((Join-Path $env:JAVA_HOME "bin/$javaName"))
+    }
+
+    $command = Get-Command java -ErrorAction SilentlyContinue
+    if ($null -ne $command) { $candidates.Add($command.Source) }
+
+    $roots = [Collections.Generic.List[string]]::new()
+    if ($script:isWindowsHost) {
+        foreach ($root in @(
+            "$env:ProgramFiles\Java",
+            "$env:ProgramFiles\Amazon Corretto",
+            "$env:ProgramFiles\Eclipse Adoptium",
+            "$env:ProgramFiles\Microsoft",
+            "$env:USERPROFILE\.jdks"
+        )) {
+            if (-not [string]::IsNullOrWhiteSpace($root) -and (Test-Path -LiteralPath $root -PathType Container)) {
+                $roots.Add($root)
+            }
+        }
+    }
+    else {
+        foreach ($root in @("/usr/lib/jvm", "/opt/java", "$HOME/.jdks")) {
+            if (Test-Path -LiteralPath $root -PathType Container) { $roots.Add($root) }
+        }
+    }
+
+    foreach ($root in $roots) {
+        Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+            $candidates.Add((Join-Path $_.FullName "bin/$javaName"))
+        }
+    }
+
+    foreach ($candidate in ($candidates | Select-Object -Unique)) {
+        if (Test-Java21Executable -Candidate $candidate) {
+            $resolvedJava = [IO.Path]::GetFullPath($candidate)
+            $resolvedHome = Split-Path (Split-Path $resolvedJava -Parent) -Parent
+            $javacName = if ($script:isWindowsHost) { "javac.exe" } else { "javac" }
+            $resolvedJavac = Join-Path $resolvedHome "bin/$javacName"
+            if (-not (Test-Path -LiteralPath $resolvedJavac -PathType Leaf)) {
+                throw "Se encontró Java 21, pero no javac en $resolvedHome"
+            }
+            return [pscustomobject]@{
+                Home = $resolvedHome
+                Java = $resolvedJava
+                Javac = $resolvedJavac
+            }
+        }
+    }
+
+    throw "No se encontró un JDK 21 completo. Configure JAVA_HOME para esta sesión."
+}
+
+function Resolve-MavenWrapper {
+    $candidate = if ($script:isWindowsHost) {
+        Join-Path $script:backendRoot "mvnw.cmd"
+    }
+    else {
+        Join-Path $script:backendRoot "mvnw"
+    }
+
+    if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+        throw "No se encontró Maven Wrapper en $candidate"
+    }
+    return $candidate
+}
+
+function Build-Backend {
+    Push-Location $script:backendRoot
+    try {
+        Invoke-Native -FilePath $script:mavenWrapper -Arguments @(
+            "-q", "-DskipTests", "package"
+        )
+    }
+    finally { Pop-Location }
+
+    $jars = @(Get-ChildItem -LiteralPath (Join-Path $script:backendRoot "target") -Filter "*.jar" -File |
+        Where-Object { $_.Name -notlike "*.original" } |
+        Sort-Object Length -Descending)
+    if ($jars.Count -eq 0) { throw "El build no produjo un JAR ejecutable" }
+    $script:backendJar = $jars[0].FullName
+}
+
+function New-BcryptHashes {
+    param([Parameter(Mandatory)][hashtable] $Passwords)
+
+    $classpathFile = Join-Path $script:tempRoot "runtime-classpath.txt"
+    Push-Location $script:backendRoot
+    try {
+        Invoke-Native -FilePath $script:mavenWrapper -Arguments @(
+            "-q",
+            "-DincludeScope=runtime",
+            "-Dmdep.outputFile=$classpathFile",
+            "dependency:build-classpath"
+        )
+    }
+    finally { Pop-Location }
+
+    if (-not (Test-Path -LiteralPath $classpathFile -PathType Leaf)) {
+        throw "Maven no produjo el classpath requerido para BCrypt"
+    }
+    $runtimeClasspath = [IO.File]::ReadAllText($classpathFile).Trim()
+    if ([string]::IsNullOrWhiteSpace($runtimeClasspath)) {
+        throw "El classpath runtime para BCrypt está vacío"
+    }
+
+    $sourcePath = Join-Path $script:tempRoot "GestudioDemoBcrypt.java"
+    $source = @'
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public final class GestudioDemoBcrypt {
+    private GestudioDemoBcrypt() {}
+
+    public static void main(String[] args) throws Exception {
+        int strength = Integer.parseInt(args[0]);
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(strength);
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(System.in, StandardCharsets.UTF_8))) {
+            boolean verify = args.length > 1 && "verify".equals(args[1]);
+            String password;
+            int pair = 0;
+            while ((password = reader.readLine()) != null) {
+                if (!password.isEmpty() && password.charAt(0) == '\uFEFF') {
+                    password = password.substring(1);
+                }
+                if (verify) {
+                    pair++;
+                    String hash = reader.readLine();
+                    if (hash == null || !encoder.matches(password, hash)) {
+                        System.err.println("BCrypt pair " + pair + " failed");
+                        System.exit(3);
+                    }
+                } else {
+                    System.out.println(encoder.encode(password));
+                }
+            }
+        }
+    }
+}
+'@
+    [IO.File]::WriteAllText($sourcePath, $source, [Text.UTF8Encoding]::new($false))
+
+    Invoke-Native -FilePath $script:javacExe -Arguments @(
+        "-encoding", "UTF-8", "-cp", $runtimeClasspath, $sourcePath
+    )
+
+    $classpath = $script:tempRoot + [IO.Path]::PathSeparator + $runtimeClasspath
+    $script:bcryptClasspath = $classpath
+    $escapedClasspath = $classpath.Replace('"', '\"')
+    $orderedUsers = @($Passwords.Keys | Sort-Object)
+    $result = @{}
+    foreach ($username in $orderedUsers) {
+        $psi = [Diagnostics.ProcessStartInfo]::new()
+        $psi.FileName = $script:javaExe
+        $psi.Arguments = "-cp `"$escapedClasspath`" GestudioDemoBcrypt 12"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $true
+        $psi.CreateNoWindow = $true
+
+        $process = [Diagnostics.Process]::new()
+        $process.StartInfo = $psi
+        [void]$process.Start()
+        try {
+            $process.StandardInput.WriteLine([string]$Passwords[$username])
+            $process.StandardInput.Close()
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+            $bcryptExitCode = $process.ExitCode
+        }
+        finally { $process.Dispose() }
+
+        if ($bcryptExitCode -ne 0) {
+            throw "El generador BCrypt falló para ${username}: $(Redact $stderr)"
+        }
+
+        $hashLines = @($stdout -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        Assert-Equal -Actual $hashLines.Count -Expected 1 -Message "Cantidad inesperada de hashes BCrypt para $username"
+        $hash = $hashLines[0].Trim()
+        if ($hash -notmatch '^\$2[aby]\$12\$.{53}$') {
+            throw "El backend generó un hash BCrypt incompatible"
+        }
+        $result[$username] = $hash
+        Add-Secret $hash
+    }
+
+    if (@($result.Values | Select-Object -Unique).Count -ne $orderedUsers.Count) {
+        throw "Los hashes BCrypt efímeros deben ser diferentes"
+    }
+
+    foreach ($username in $orderedUsers) {
+        Assert-BcryptPair -Password ([string]$Passwords[$username]) -Hash ([string]$result[$username]) -Username $username
+    }
+
+    return $result
+}
+
+function Assert-BcryptPair {
+    param(
+        [Parameter(Mandatory)][string] $Password,
+        [Parameter(Mandatory)][string] $Hash,
+        [Parameter(Mandatory)][string] $Username
+    )
+
+    $psi = [Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $script:javaExe
+    $psi.Arguments = "-cp `"$($script:bcryptClasspath.Replace('"', '\"'))`" GestudioDemoBcrypt 12 verify"
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $psi
+    [void]$process.Start()
+    try {
+        $process.StandardInput.WriteLine($Password)
+        $process.StandardInput.WriteLine($Hash)
+        $process.StandardInput.Close()
+        [void]$process.StandardOutput.ReadToEnd()
+        $stderr = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+        if ($process.ExitCode -ne 0) {
+            throw "La password efímera de $Username no coincide con el BCrypt persistido: $(Redact $stderr)"
+        }
+    }
+    finally { $process.Dispose() }
+}
+
+function Configure-BackendEnvironment {
+    Set-ScopedEnvironmentVariable -Name "SPRING_PROFILES_ACTIVE" -Value "dev"
+    Set-ScopedEnvironmentVariable -Name "SPRING_DATASOURCE_URL" -Value "jdbc:postgresql://127.0.0.1:$($script:dbPort)/$($script:postgresDb)"
+    Set-ScopedEnvironmentVariable -Name "SPRING_DATASOURCE_USERNAME" -Value $script:postgresUser
+    Set-ScopedEnvironmentVariable -Name "SPRING_DATASOURCE_PASSWORD" -Value $script:postgresPassword
+    Set-ScopedEnvironmentVariable -Name "SPRING_JPA_HIBERNATE_DDL_AUTO" -Value "validate"
+    Set-ScopedEnvironmentVariable -Name "SPRING_FLYWAY_ENABLED" -Value "true"
+    Set-ScopedEnvironmentVariable -Name "SPRING_FLYWAY_BASELINE_ON_MIGRATE" -Value "false"
+    Set-ScopedEnvironmentVariable -Name "SPRING_FLYWAY_BASELINE_VERSION" -Value "1"
+    Set-ScopedEnvironmentVariable -Name "SERVER_PORT" -Value ([string]$script:backendPort)
+    Set-ScopedEnvironmentVariable -Name "JWT_SECRET" -Value $script:jwtSecret
+    Set-ScopedEnvironmentVariable -Name "JWT_ISSUER" -Value "gestudio-demo-validation"
+    Set-ScopedEnvironmentVariable -Name "JWT_ACCESS_TOKEN_TTL" -Value "PT15M"
+    Set-ScopedEnvironmentVariable -Name "JWT_REFRESH_TOKEN_TTL" -Value "PT2H"
+    Set-ScopedEnvironmentVariable -Name "APP_TIME_ZONE" -Value "America/Argentina/Buenos_Aires"
+    Set-ScopedEnvironmentVariable -Name "APP_SCHEDULING_ENABLED" -Value "false"
+    Set-ScopedEnvironmentVariable -Name "APP_BOOTSTRAP_SUPERADMIN_ENABLED" -Value "false"
+    Set-ScopedEnvironmentVariable -Name "APP_BOOTSTRAP_ADMIN_ENABLED" -Value "false"
+    Set-ScopedEnvironmentVariable -Name "APP_BOOTSTRAP_ADMIN_RESET_EXISTING_PASSWORD" -Value "false"
+    Set-ScopedEnvironmentVariable -Name "APP_SECURITY_REFRESH_COOKIE_SECURE" -Value "false"
+    Set-ScopedEnvironmentVariable -Name "APP_CORS_ALLOWED_ORIGINS" -Value $script:frontendOrigin
+    Set-ScopedEnvironmentVariable -Name "APP_RECEIPTS_PATH" -Value $script:receiptsRoot
+    Set-ScopedEnvironmentVariable -Name "GESTUDIO_HOME" -Value $script:tempRoot
+    Set-ScopedEnvironmentVariable -Name "LOGGING_LEVEL_ROOT" -Value "WARN"
+}
+
+function Start-Backend {
+    if ($null -ne $script:backendProcess -and -not $script:backendProcess.HasExited) {
+        throw "Ya existe un backend iniciado por el validador"
+    }
+
+    Remove-Item -LiteralPath $script:backendStdout, $script:backendStderr -Force -ErrorAction SilentlyContinue
+    $argumentString = "-jar `"$($script:backendJar)`""
+    $startParameters = @{
+        FilePath = $script:javaExe
+        ArgumentList = $argumentString
+        WorkingDirectory = $script:backendRoot
+        PassThru = $true
+        RedirectStandardOutput = $script:backendStdout
+        RedirectStandardError = $script:backendStderr
+    }
+    if ($script:isWindowsHost) { $startParameters.WindowStyle = 'Hidden' }
+    $script:backendProcess = Start-Process @startParameters
+}
+
+function Get-BackendLogTail {
+    $lines = [Collections.Generic.List[string]]::new()
+    foreach ($path in @($script:backendStdout, $script:backendStderr)) {
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            Get-Content -LiteralPath $path -Tail 100 -ErrorAction SilentlyContinue | ForEach-Object {
+                $lines.Add($_.ToString())
+            }
+        }
+    }
+    return Redact (($lines -join "`n").Trim())
+}
+
+function Wait-BackendAvailable {
+    while ((Get-Date) -lt $script:deadline) {
+        if ($null -ne $script:backendProcess -and $script:backendProcess.HasExited) {
+            throw "El backend terminó con código $($script:backendProcess.ExitCode): $(Get-BackendLogTail)"
+        }
+
+        try {
+            $result = Invoke-HttpRaw -Method "GET" -Uri ($script:apiBase + "/usuarios/perfil") -Body $null -Token $null
+            if ($result.Status -eq 401) { return }
+        }
+        catch {
+            # El socket todavía puede no estar escuchando.
+        }
+        Start-Sleep -Milliseconds 750
+    }
+    throw "Timeout esperando disponibilidad del backend: $(Get-BackendLogTail)"
+}
+
+function Stop-Backend {
+    if ($null -eq $script:backendProcess) { return }
+    try {
+        if (-not $script:backendProcess.HasExited) {
+            Stop-Process -Id $script:backendProcess.Id -Force -ErrorAction SilentlyContinue
+            try { Wait-Process -Id $script:backendProcess.Id -Timeout 15 -ErrorAction SilentlyContinue }
+            catch { }
+        }
+    }
+    finally {
+        $script:backendProcess.Dispose()
+        $script:backendProcess = $null
+    }
+}
+
+function Invoke-HttpRaw {
+    param(
+        [Parameter(Mandatory)][string] $Method,
+        [Parameter(Mandatory)][string] $Uri,
+        $Body,
+        [AllowNull()][string] $Token
+    )
+
+    Assert-Deadline
+    $request = [Net.Http.HttpRequestMessage]::new([Net.Http.HttpMethod]::new($Method), $Uri)
+    try {
+        if (-not [string]::IsNullOrWhiteSpace($Token)) {
+            $request.Headers.Authorization = [Net.Http.Headers.AuthenticationHeaderValue]::new("Bearer", $Token)
+        }
+        if ($null -ne $Body) {
+            $json = $Body | ConvertTo-Json -Depth 15 -Compress
+            if ($Body -is [Collections.IDictionary] -and $Body.Contains('contrasena')) {
+                $roundTrip = $json | ConvertFrom-Json
+                Assert-Equal -Actual ([string]$roundTrip.contrasena) -Expected ([string]$Body['contrasena']) -Message "La serialización HTTP alteró la password efímera"
+            }
+            $request.Content = [Net.Http.StringContent]::new($json, [Text.Encoding]::UTF8, "application/json")
+        }
+        $response = $script:http.SendAsync($request).GetAwaiter().GetResult()
+        try {
+            $raw = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            if ($script:VerboseHttp) {
+                Write-Host "[HTTP] $Method $Uri -> $([int]$response.StatusCode)"
+            }
+            return [pscustomobject]@{
+                Status = [int]$response.StatusCode
+                Body = $raw
+            }
+        }
+        finally { $response.Dispose() }
+    }
+    finally { $request.Dispose() }
+}
+
+function Invoke-Api {
+    param(
+        [Parameter(Mandatory)][string] $Method,
+        [Parameter(Mandatory)][string] $Path,
+        $Body = $null,
+        [AllowNull()][string] $Token = $null,
+        [Parameter(Mandatory)][int] $ExpectedStatus
+    )
+
+    $result = Invoke-HttpRaw -Method $Method -Uri ($script:apiBase + $Path) -Body $Body -Token $Token
+    if ($result.Status -ne $ExpectedStatus) {
+        throw "$Method $Path devolvió estado inesperado (esperado=$ExpectedStatus, actual=$($result.Status), body=$(Redact $result.Body))"
+    }
+
+    $json = $null
+    if (-not [string]::IsNullOrWhiteSpace($result.Body)) {
+        try { $json = $result.Body | ConvertFrom-Json }
+        catch { $json = $null }
+    }
+    return [pscustomobject]@{
+        Status = $result.Status
+        Body = $result.Body
+        Json = $json
+    }
+}
+
+function Register-RefreshCookieSecret {
+    $cookie = $script:cookieContainer.GetCookies([Uri]($script:apiBase + "/login"))["gestudio_refresh"]
+    if ($null -ne $cookie -and -not [string]::IsNullOrWhiteSpace($cookie.Value)) {
+        Add-Secret ([string]$cookie.Value)
+    }
+}
+
+function Login-Actor {
+    param(
+        [Parameter(Mandatory)][string] $Username,
+        [Parameter(Mandatory)][string] $ExpectedRole
+    )
+
+    $storedHash = Invoke-Sql "SELECT contrasena FROM usuarios WHERE lower(nombre_usuario)='$Username';"
+    Add-Secret $storedHash
+    Assert-Equal -Actual $storedHash -Expected $script:demoHashes[$Username] -Message "El backend alteró el hash de $Username antes del login"
+    Assert-True -Condition (-not [string]::IsNullOrWhiteSpace([string]$script:demoPasswords[$Username])) -Message "Password efímera ausente para $Username"
+    Assert-BcryptPair -Password ([string]$script:demoPasswords[$Username]) -Hash $storedHash -Username $Username
+
+    try {
+        $response = Invoke-Api -Method "POST" -Path "/login" -Body @{
+            nombreUsuario = $Username
+            contrasena = [string]($script:demoPasswords[$Username])
+        } -Token $null -ExpectedStatus 200
+    }
+    catch {
+        throw "Login de ${Username}: $($_.Exception.Message)"
+    }
+
+    Assert-True -Condition ($null -ne $response.Json) -Message "Login de $Username sin JSON"
+    Assert-True -Condition (-not [string]::IsNullOrWhiteSpace([string]$response.Json.accessToken)) -Message "Login de $Username sin access token"
+    Assert-True -Condition (@($response.Json.usuario.roles) -contains $ExpectedRole) -Message "Login de $Username con rol inesperado"
+    Assert-Equal -Actual ([bool]$response.Json.usuario.activo) -Expected $true -Message "Usuario $Username inactivo"
+
+    $token = [string]$response.Json.accessToken
+    Add-Secret $token
+    Register-RefreshCookieSecret
+    $script:actorTokens[$Username] = $token
+    return $response.Json.usuario
+}
+
+function Assert-Endpoint {
+    param(
+        [Parameter(Mandatory)][string] $Stage,
+        [Parameter(Mandatory)][string] $Method,
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $Actor,
+        [Parameter(Mandatory)][int] $ExpectedStatus,
+        $Body = $null
+    )
+
+    Invoke-Api -Method $Method -Path $Path -Body $Body -Token $script:actorTokens[$Actor] -ExpectedStatus $ExpectedStatus | Out-Null
+    Add-Result -Stage $Stage -Result "PASS" -Detail "$Actor -> $Method $Path = $ExpectedStatus"
+}
+
+function Get-RbacSnapshot {
+    return Invoke-Sql -Query @"
+SELECT jsonb_build_object(
+    'rolesCount', (SELECT count(*) FROM roles),
+    'rolesHash', (SELECT md5(COALESCE(string_agg(id::text || '|' || codigo || '|' || activo::text || '|' || sistema::text || '|' || editable::text, E'\n' ORDER BY id), '')) FROM roles),
+    'permissionsCount', (SELECT count(*) FROM permisos),
+    'permissionsHash', (SELECT md5(COALESCE(string_agg(id::text || '|' || codigo || '|' || activo::text || '|' || sistema::text || '|' || modulo || '|' || descripcion, E'\n' ORDER BY id), '')) FROM permisos),
+    'matrixCount', (SELECT count(*) FROM rol_permisos),
+    'matrixHash', (SELECT md5(COALESCE(string_agg(rol_id::text || '|' || permiso_id::text, E'\n' ORDER BY rol_id, permiso_id), '')) FROM rol_permisos)
+)::text;
+"@
+}
+
+function Get-DemoSnapshot {
+    return Invoke-Sql -Query @"
+WITH demo_users AS (
+    SELECT id FROM usuarios WHERE lower(nombre_usuario) LIKE 'demo-%'
+), demo_alumnos AS (
+    SELECT id FROM alumnos WHERE documento LIKE 'DEMO-DNI-%'
+), demo_inscripciones AS (
+    SELECT i.id FROM inscripciones i JOIN demo_alumnos a ON a.id = i.alumno_id
+), demo_mensualidades AS (
+    SELECT m.id FROM mensualidades m JOIN demo_inscripciones i ON i.id = m.inscripcion_id
+), demo_matriculas AS (
+    SELECT m.id FROM matriculas m JOIN demo_alumnos a ON a.id = m.alumno_id
+), demo_cargos AS (
+    SELECT c.id FROM cargos c JOIN demo_alumnos a ON a.id = c.alumno_id
+), demo_pagos AS (
+    SELECT p.id FROM pagos p JOIN demo_alumnos a ON a.id = p.alumno_id
+), demo_ventas AS (
+    SELECT v.id FROM ventas_stock v JOIN demo_alumnos a ON a.id = v.alumno_id
+), demo_stocks AS (
+    SELECT s.id FROM stocks s WHERE s.codigo_barras LIKE 'DEMO-STOCK-%'
+), demo_asistencia_mensual AS (
+    SELECT am.id FROM asistencias_mensuales am
+    JOIN disciplinas d ON d.id = am.disciplina_id
+    WHERE d.nombre LIKE 'DEMO · %'
+), demo_asistencia_alumno AS (
+    SELECT aam.id FROM asistencias_alumno_mensual aam
+    JOIN demo_inscripciones i ON i.id = aam.inscripcion_id
+)
+SELECT (jsonb_build_object(
+    'usersCount', (SELECT count(*) FROM demo_users),
+    'usersIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_users),
+    'usersHash', (SELECT md5(COALESCE(string_agg(u.id::text || '|' || lower(u.nombre_usuario) || '|' || u.rol_id::text || '|' || u.activo::text || '|' || u.auth_version::text, E'\n' ORDER BY u.id), '')) FROM usuarios u JOIN demo_users du ON du.id=u.id),
+    'userRolesCount', (SELECT count(*) FROM usuario_roles ur JOIN demo_users u ON u.id = ur.usuario_id),
+    'userRolesIds', (SELECT md5(COALESCE(string_agg(ur.usuario_id::text || ':' || ur.rol_id::text, ',' ORDER BY ur.usuario_id, ur.rol_id), '')) FROM usuario_roles ur JOIN demo_users u ON u.id = ur.usuario_id),
+    'studentsCount', (SELECT count(*) FROM demo_alumnos),
+    'studentsIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_alumnos),
+    'enrollmentsCount', (SELECT count(*) FROM demo_inscripciones),
+    'enrollmentsIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_inscripciones),
+    'enrollmentsHash', (SELECT md5(COALESCE(string_agg(i.id::text || '|' || i.alumno_id::text || '|' || i.disciplina_id::text || '|' || i.estado || '|' || COALESCE(i.costo_particular::text,''), E'\n' ORDER BY i.id), '')) FROM inscripciones i JOIN demo_inscripciones di ON di.id=i.id),
+    'monthlyCount', (SELECT count(*) FROM demo_mensualidades),
+    'monthlyIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_mensualidades),
+    'monthlyHash', (SELECT md5(COALESCE(string_agg(m.id::text || '|' || m.inscripcion_id::text || '|' || m.anio::text || '|' || m.mes::text || '|' || m.estado, E'\n' ORDER BY m.id), '')) FROM mensualidades m JOIN demo_mensualidades dm ON dm.id=m.id),
+    'registrationsCount', (SELECT count(*) FROM demo_matriculas),
+    'registrationsIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_matriculas),
+    'registrationsHash', (SELECT md5(COALESCE(string_agg(m.id::text || '|' || m.alumno_id::text || '|' || m.anio::text || '|' || m.estado, E'\n' ORDER BY m.id), '')) FROM matriculas m JOIN demo_matriculas dm ON dm.id=m.id),
+    'chargesCount', (SELECT count(*) FROM demo_cargos),
+    'chargesIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_cargos),
+    'chargesHash', (SELECT md5(COALESCE(string_agg(c.id::text || '|' || c.tipo || '|' || c.importe_original::text || '|' || c.estado || '|' || COALESCE(c.idempotency_key,''), E'\n' ORDER BY c.id), '')) FROM cargos c JOIN demo_cargos dc ON dc.id=c.id),
+    'liquidationsCount', (SELECT count(*) FROM cargo_liquidaciones cl JOIN demo_cargos c ON c.id = cl.cargo_id),
+    'paymentsCount', (SELECT count(*) FROM demo_pagos),
+    'paymentsIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_pagos),
+    'paymentsHash', (SELECT md5(COALESCE(string_agg(p.id::text || '|' || p.monto_recibido::text || '|' || p.estado || '|' || p.idempotency_key || '|' || COALESCE(p.reversal_idempotency_key,''), E'\n' ORDER BY p.id), '')) FROM pagos p JOIN demo_pagos dp ON dp.id=p.id),
+    'applicationsCount', (SELECT count(*) FROM aplicaciones_pago ap JOIN demo_pagos p ON p.id = ap.pago_id),
+    'applicationsIds', (SELECT md5(COALESCE(string_agg(ap.id::text, ',' ORDER BY ap.id), '')) FROM aplicaciones_pago ap JOIN demo_pagos p ON p.id = ap.pago_id),
+    'applicationsHash', (SELECT md5(COALESCE(string_agg(ap.id::text || '|' || ap.pago_id::text || '|' || ap.cargo_id::text || '|' || ap.importe_aplicado::text || '|' || ap.estado, E'\n' ORDER BY ap.id), '')) FROM aplicaciones_pago ap JOIN demo_pagos p ON p.id=ap.pago_id),
+    'salesCount', (SELECT count(*) FROM demo_ventas),
+    'salesIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM demo_ventas),
+    'salesHash', (SELECT md5(COALESCE(string_agg(v.id::text || '|' || v.stock_id::text || '|' || v.cantidad::text || '|' || v.precio_unitario::text || '|' || v.estado || '|' || v.idempotency_key, E'\n' ORDER BY v.id), '')) FROM ventas_stock v JOIN demo_ventas dv ON dv.id=v.id),
+    'cashCount', (SELECT count(*) FROM movimientos_caja WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'cashIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM movimientos_caja WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'cashHash', (SELECT md5(COALESCE(string_agg(id::text || '|' || tipo || '|' || importe::text || '|' || metodo_pago_id::text || '|' || COALESCE(movimiento_revertido_id::text,'') || '|' || idempotency_key, E'\n' ORDER BY id), '')) FROM movimientos_caja WHERE idempotency_key LIKE 'demo-seed:v1:%')
+) || jsonb_build_object(
+    'creditCount', (SELECT count(*) FROM movimientos_credito WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'creditIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM movimientos_credito WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'creditHash', (SELECT md5(COALESCE(string_agg(id::text || '|' || alumno_id::text || '|' || tipo || '|' || importe::text || '|' || COALESCE(cargo_id::text,'') || '|' || COALESCE(movimiento_revertido_id::text,'') || '|' || idempotency_key, E'\n' ORDER BY id), '')) FROM movimientos_credito WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'stockMovementsCount', (SELECT count(*) FROM movimientos_stock WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'stockMovementIds', (SELECT md5(COALESCE(string_agg(id::text, ',' ORDER BY id), '')) FROM movimientos_stock WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'stockMovementsHash', (SELECT md5(COALESCE(string_agg(id::text || '|' || stock_id::text || '|' || tipo || '|' || cantidad::text || '|' || COALESCE(venta_stock_id::text,'') || '|' || COALESCE(movimiento_revertido_id::text,'') || '|' || idempotency_key, E'\n' ORDER BY id), '')) FROM movimientos_stock WHERE idempotency_key LIKE 'demo-seed:v1:%'),
+    'stocksCount', (SELECT count(*) FROM demo_stocks),
+    'stocksHash', (SELECT md5(COALESCE(string_agg(s.id::text || ':' || s.cantidad_actual::text, ',' ORDER BY s.id), '')) FROM stocks s JOIN demo_stocks ds ON ds.id = s.id),
+    'attendanceSheetsCount', (SELECT count(*) FROM demo_asistencia_mensual),
+    'attendanceStudentsCount', (SELECT count(*) FROM demo_asistencia_alumno),
+    'attendanceDailyCount', (SELECT count(*) FROM asistencias_diarias ad JOIN demo_asistencia_alumno a ON a.id = ad.asistencia_alumno_mensual_id),
+    'attendanceHash', (SELECT md5(COALESCE(string_agg(ad.id::text || '|' || ad.asistencia_alumno_mensual_id::text || '|' || ad.fecha::text || '|' || ad.estado || '|' || ad.vigente::text, E'\n' ORDER BY ad.id), '')) FROM asistencias_diarias ad JOIN demo_asistencia_alumno a ON a.id=ad.asistencia_alumno_mensual_id),
+    'receiptsCount', (SELECT count(*) FROM recibos r JOIN demo_pagos p ON p.id = r.pago_id),
+    'receiptIds', (SELECT md5(COALESCE(string_agg(r.id::text, ',' ORDER BY r.id), '')) FROM recibos r JOIN demo_pagos p ON p.id = r.pago_id),
+    'receiptsHash', (SELECT md5(COALESCE(string_agg(r.id::text || '|' || r.pago_id::text || '|' || COALESCE(r.storage_key,'') || '|' || COALESCE(r.generado_at::text,'') || '|' || COALESCE(r.enviado_at::text,''), E'\n' ORDER BY r.id), '')) FROM recibos r JOIN demo_pagos p ON p.id=r.pago_id),
+    'outboxCount', (SELECT count(*) FROM recibos_pendientes rp JOIN demo_pagos p ON p.id = rp.pago_id),
+    'outboxIds', (SELECT md5(COALESCE(string_agg(rp.id::text, ',' ORDER BY rp.id), '')) FROM recibos_pendientes rp JOIN demo_pagos p ON p.id = rp.pago_id),
+    'outboxHash', (SELECT md5(COALESCE(string_agg(rp.id::text || '|' || rp.pago_id::text || '|' || rp.tipo || '|' || rp.estado || '|' || rp.intentos::text || '|' || rp.idempotency_key || '|' || COALESCE(rp.processed_at::text,''), E'\n' ORDER BY rp.id), '')) FROM recibos_pendientes rp JOIN demo_pagos p ON p.id=rp.pago_id),
+    'registeredPayments', (SELECT COALESCE(sum(p.monto_recibido), 0)::text FROM pagos p JOIN demo_pagos dp ON dp.id = p.id WHERE p.estado = 'REGISTRADO'),
+    'activeApplications', (SELECT COALESCE(sum(ap.importe_aplicado), 0)::text FROM aplicaciones_pago ap JOIN demo_pagos p ON p.id = ap.pago_id WHERE ap.estado = 'APLICADA'),
+    'activePaymentCredit', (SELECT COALESCE(sum(CASE mc.tipo WHEN 'GENERACION' THEN mc.importe WHEN 'REVERSO' THEN -mc.importe ELSE 0 END), 0)::text FROM movimientos_credito mc WHERE mc.idempotency_key LIKE 'demo-seed:v1:%' AND (mc.pago_id IS NOT NULL OR (mc.tipo = 'REVERSO' AND mc.idempotency_key LIKE 'demo-seed:v1:credito:reversa-generacion%'))),
+    'netCredit', (SELECT COALESCE(sum(CASE mc.tipo WHEN 'GENERACION' THEN mc.importe WHEN 'AJUSTE_CREDITO' THEN mc.importe WHEN 'CONSUMO' THEN -mc.importe WHEN 'AJUSTE_DEBITO' THEN -mc.importe WHEN 'REVERSO' THEN CASE WHEN original.tipo = 'CONSUMO' THEN mc.importe ELSE -mc.importe END ELSE 0 END), 0)::text FROM movimientos_credito mc LEFT JOIN movimientos_credito original ON original.id = mc.movimiento_revertido_id WHERE mc.idempotency_key LIKE 'demo-seed:v1:%')
+))::text;
+"@
+}
+
+function Assert-ExpectedDemoCounts {
+    param([Parameter(Mandatory)] $Snapshot)
+
+    $expected = [ordered]@{
+        usersCount = 5
+        userRolesCount = 5
+        studentsCount = 28
+        enrollmentsCount = 34
+        monthlyCount = 70
+        registrationsCount = 26
+        chargesCount = 115
+        liquidationsCount = 115
+        paymentsCount = 48
+        applicationsCount = 82
+        salesCount = 6
+        cashCount = 61
+        creditCount = 11
+        stockMovementsCount = 14
+        stocksCount = 6
+        attendanceSheetsCount = 6
+        attendanceStudentsCount = 18
+        attendanceDailyCount = 54
+        receiptsCount = 48
+        outboxCount = 48
+    }
+
+    foreach ($entry in $expected.GetEnumerator()) {
+        $property = $Snapshot.PSObject.Properties[$entry.Key]
+        if ($null -eq $property) { throw "Snapshot sin propiedad $($entry.Key)" }
+        Assert-Equal -Actual ([int64]$property.Value) -Expected ([int64]$entry.Value) -Message "Conteo demo inesperado para $($entry.Key)"
+    }
+
+    $expectedTotals = [ordered]@{
+        registeredPayments = "1956700.00"
+        activeApplications = "1938700.00"
+        activePaymentCredit = "18000.00"
+        netCredit = "21000.00"
+    }
+    foreach ($entry in $expectedTotals.GetEnumerator()) {
+        $property = $Snapshot.PSObject.Properties[$entry.Key]
+        if ($null -eq $property) { throw "Snapshot sin propiedad $($entry.Key)" }
+        $actual = [decimal]::Parse([string]$property.Value, [Globalization.CultureInfo]::InvariantCulture)
+        $expectedTotal = [decimal]::Parse($entry.Value, [Globalization.CultureInfo]::InvariantCulture)
+        Assert-Equal -Actual $actual -Expected $expectedTotal -Message "Total demo inesperado para $($entry.Key)"
+    }
+}
+
+function Invoke-IntegrityChecks {
+    Assert-SqlZero -Stage "Usuarios demo con roles inactivos" -Query @"
+SELECT count(*) FROM usuarios u
+JOIN usuario_roles ur ON ur.usuario_id = u.id
+JOIN roles r ON r.id = ur.rol_id
+WHERE lower(u.nombre_usuario) LIKE 'demo-%' AND NOT r.activo;
+"@
+
+    Assert-SqlZero -Stage "Usuario operativo con rol Profesor" -Query @"
+SELECT count(*) FROM usuarios u
+JOIN usuario_roles ur ON ur.usuario_id = u.id
+JOIN roles r ON r.id = ur.rol_id
+WHERE lower(u.nombre_usuario) LIKE 'demo-%' AND r.codigo = 'PROFESOR';
+"@
+
+    Assert-SqlZero -Stage "FK demo huérfanas" -Query @"
+WITH demo_alumnos AS (SELECT id FROM alumnos WHERE documento LIKE 'DEMO-DNI-%')
+SELECT sum(invalidos) FROM (
+    SELECT count(*) AS invalidos FROM inscripciones i JOIN demo_alumnos da ON da.id=i.alumno_id LEFT JOIN disciplinas d ON d.id=i.disciplina_id WHERE d.id IS NULL
+    UNION ALL SELECT count(*) FROM cargos c JOIN demo_alumnos da ON da.id=c.alumno_id LEFT JOIN alumnos a ON a.id=c.alumno_id WHERE a.id IS NULL
+    UNION ALL SELECT count(*) FROM pagos p JOIN demo_alumnos da ON da.id=p.alumno_id LEFT JOIN metodo_pagos mp ON mp.id=p.metodo_pago_id WHERE mp.id IS NULL
+    UNION ALL SELECT count(*) FROM ventas_stock v JOIN demo_alumnos da ON da.id=v.alumno_id LEFT JOIN stocks s ON s.id=v.stock_id WHERE s.id IS NULL
+) q;
+"@
+
+    Assert-SqlZero -Stage "Aplicaciones superiores al pago" -Query @"
+SELECT count(*) FROM (
+    SELECT p.id
+    FROM pagos p
+    JOIN alumnos a ON a.id=p.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+    LEFT JOIN aplicaciones_pago ap ON ap.pago_id=p.id AND ap.estado='APLICADA'
+    GROUP BY p.id, p.monto_recibido
+    HAVING COALESCE(sum(ap.importe_aplicado),0) > p.monto_recibido
+) q;
+"@
+
+    Assert-SqlZero -Stage "Aplicaciones superiores al cargo" -Query @"
+WITH pagos AS (
+    SELECT cargo_id, sum(importe_aplicado) AS importe
+    FROM aplicaciones_pago WHERE estado='APLICADA' GROUP BY cargo_id
+), credito AS (
+    SELECT cargo_id, sum(importe) AS importe FROM (
+        SELECT cargo_id, importe FROM movimientos_credito WHERE tipo='CONSUMO'
+        UNION ALL
+        SELECT original.cargo_id, -reverso.importe
+        FROM movimientos_credito reverso
+        JOIN movimientos_credito original ON original.id=reverso.movimiento_revertido_id
+        WHERE reverso.tipo='REVERSO' AND original.tipo='CONSUMO'
+    ) x GROUP BY cargo_id
+)
+SELECT count(*) FROM cargos c
+JOIN alumnos a ON a.id=c.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+LEFT JOIN pagos p ON p.cargo_id=c.id
+LEFT JOIN credito cr ON cr.cargo_id=c.id
+WHERE COALESCE(p.importe,0) + COALESCE(cr.importe,0) > c.importe_original;
+"@
+
+    Assert-SqlZero -Stage "Estados de cargo incoherentes" -Query @"
+WITH pagos AS (
+    SELECT cargo_id, sum(importe_aplicado) AS importe FROM aplicaciones_pago WHERE estado='APLICADA' GROUP BY cargo_id
+), credito AS (
+    SELECT cargo_id, sum(importe) AS importe FROM (
+        SELECT cargo_id, importe FROM movimientos_credito WHERE tipo='CONSUMO'
+        UNION ALL
+        SELECT original.cargo_id, -reverso.importe FROM movimientos_credito reverso
+        JOIN movimientos_credito original ON original.id=reverso.movimiento_revertido_id
+        WHERE reverso.tipo='REVERSO' AND original.tipo='CONSUMO'
+    ) x GROUP BY cargo_id
+)
+SELECT count(*) FROM cargos c
+JOIN alumnos a ON a.id=c.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+LEFT JOIN pagos p ON p.cargo_id=c.id
+LEFT JOIN credito cr ON cr.cargo_id=c.id
+WHERE c.estado <> CASE
+    WHEN c.estado='ANULADO' THEN 'ANULADO'
+    WHEN c.importe_original-COALESCE(p.importe,0)-COALESCE(cr.importe,0)=0 THEN 'PAGADO'
+    WHEN c.importe_original-COALESCE(p.importe,0)-COALESCE(cr.importe,0)<c.importe_original THEN 'PARCIAL'
+    ELSE 'PENDIENTE' END;
+"@
+
+    Assert-SqlZero -Stage "Crédito demo negativo" -Query @"
+SELECT count(*) FROM (
+    SELECT mc.alumno_id, sum(CASE mc.tipo
+        WHEN 'GENERACION' THEN mc.importe
+        WHEN 'AJUSTE_CREDITO' THEN mc.importe
+        WHEN 'CONSUMO' THEN -mc.importe
+        WHEN 'AJUSTE_DEBITO' THEN -mc.importe
+        WHEN 'REVERSO' THEN CASE WHEN original.tipo='CONSUMO' THEN mc.importe ELSE -mc.importe END
+        ELSE 0 END) AS saldo
+    FROM movimientos_credito mc
+    LEFT JOIN movimientos_credito original ON original.id=mc.movimiento_revertido_id
+    WHERE mc.idempotency_key LIKE 'demo-seed:v1:%'
+    GROUP BY mc.alumno_id
+    HAVING sum(CASE mc.tipo
+        WHEN 'GENERACION' THEN mc.importe
+        WHEN 'AJUSTE_CREDITO' THEN mc.importe
+        WHEN 'CONSUMO' THEN -mc.importe
+        WHEN 'AJUSTE_DEBITO' THEN -mc.importe
+        WHEN 'REVERSO' THEN CASE WHEN original.tipo='CONSUMO' THEN mc.importe ELSE -mc.importe END
+        ELSE 0 END) < 0
+) q;
+"@
+
+    Assert-SqlZero -Stage "Stock controlado inconsistente" -Query @"
+WITH libro AS (
+    SELECT ms.stock_id, sum(CASE ms.tipo
+        WHEN 'INGRESO' THEN ms.cantidad
+        WHEN 'AJUSTE_POSITIVO' THEN ms.cantidad
+        WHEN 'REVERSO' THEN ms.cantidad
+        WHEN 'VENTA' THEN -ms.cantidad
+        WHEN 'AJUSTE_NEGATIVO' THEN -ms.cantidad
+        ELSE 0 END) AS cantidad
+    FROM movimientos_stock ms
+    WHERE ms.idempotency_key LIKE 'demo-seed:v1:%'
+    GROUP BY ms.stock_id
+)
+SELECT count(*) FROM stocks s JOIN libro l ON l.stock_id=s.id
+WHERE s.requiere_control_de_stock AND (s.cantidad_actual<0 OR s.cantidad_actual<>l.cantidad);
+"@
+
+    Assert-SqlZero -Stage "Ventas demo inconsistentes" -Query @"
+SELECT count(*) FROM ventas_stock v
+JOIN alumnos a ON a.id=v.alumno_id AND a.documento LIKE 'DEMO-DNI-%'
+LEFT JOIN cargos c ON c.venta_stock_id=v.id
+LEFT JOIN movimientos_stock original ON original.venta_stock_id=v.id AND original.tipo='VENTA'
+LEFT JOIN movimientos_stock reverso ON reverso.movimiento_revertido_id=original.id AND reverso.tipo='REVERSO'
+WHERE c.id IS NULL OR original.id IS NULL
+   OR (v.estado='REGISTRADA' AND (c.estado='ANULADO' OR reverso.id IS NOT NULL))
+   OR (v.estado='ANULADA' AND (c.estado<>'ANULADO' OR reverso.id IS NULL));
+"@
+
+    Assert-SqlZero -Stage "Períodos demo duplicados" -Query @"
+SELECT sum(duplicados) FROM (
+    SELECT count(*) AS duplicados FROM (SELECT inscripcion_id,anio,mes FROM mensualidades GROUP BY inscripcion_id,anio,mes HAVING count(*)>1) a
+    UNION ALL SELECT count(*) FROM (SELECT alumno_id,anio FROM matriculas GROUP BY alumno_id,anio HAVING count(*)>1) b
+    UNION ALL SELECT count(*) FROM (SELECT disciplina_id,anio,mes FROM asistencias_mensuales GROUP BY disciplina_id,anio,mes HAVING count(*)>1) c
+    UNION ALL SELECT count(*) FROM (SELECT disciplina_id,vigente_desde FROM disciplina_tarifas GROUP BY disciplina_id,vigente_desde HAVING count(*)>1) d
+    UNION ALL SELECT count(*) FROM (SELECT inscripcion_id,vigente_desde FROM inscripcion_condiciones_economicas GROUP BY inscripcion_id,vigente_desde HAVING count(*)>1) e
+) q;
+"@
+
+    Assert-SqlZero -Stage "Idempotencia demo duplicada" -Query @"
+SELECT sum(duplicados) FROM (
+    SELECT count(*) AS duplicados FROM (SELECT idempotency_key FROM pagos WHERE idempotency_key LIKE 'demo-seed:v1:%' GROUP BY idempotency_key HAVING count(*)>1) a
+    UNION ALL SELECT count(*) FROM (SELECT idempotency_key FROM ventas_stock WHERE idempotency_key LIKE 'demo-seed:v1:%' GROUP BY idempotency_key HAVING count(*)>1) b
+    UNION ALL SELECT count(*) FROM (SELECT idempotency_key FROM movimientos_caja WHERE idempotency_key LIKE 'demo-seed:v1:%' GROUP BY idempotency_key HAVING count(*)>1) c
+    UNION ALL SELECT count(*) FROM (SELECT idempotency_key FROM movimientos_credito WHERE idempotency_key LIKE 'demo-seed:v1:%' GROUP BY idempotency_key HAVING count(*)>1) d
+    UNION ALL SELECT count(*) FROM (SELECT idempotency_key FROM movimientos_stock WHERE idempotency_key LIKE 'demo-seed:v1:%' GROUP BY idempotency_key HAVING count(*)>1) e
+    UNION ALL SELECT count(*) FROM (SELECT idempotency_key FROM recibos_pendientes WHERE idempotency_key LIKE 'demo-seed:v1:%' GROUP BY idempotency_key HAVING count(*)>1) f
+) q;
+"@
+
+    Assert-SqlZero -Stage "Recibos u outbox duplicados" -Query @"
+SELECT sum(duplicados) FROM (
+    SELECT count(*) AS duplicados FROM (SELECT pago_id FROM recibos GROUP BY pago_id HAVING count(*)>1) a
+    UNION ALL SELECT count(*) FROM (SELECT pago_id,tipo FROM recibos_pendientes GROUP BY pago_id,tipo HAVING count(*)>1) b
+) q;
+"@
+
+    Assert-SqlZero -Stage "Reversiones demo duplicadas" -Query @"
+SELECT sum(duplicados) FROM (
+    SELECT count(*) AS duplicados FROM (SELECT movimiento_revertido_id FROM movimientos_caja WHERE movimiento_revertido_id IS NOT NULL GROUP BY movimiento_revertido_id HAVING count(*)>1) a
+    UNION ALL SELECT count(*) FROM (SELECT movimiento_revertido_id FROM movimientos_credito WHERE movimiento_revertido_id IS NOT NULL GROUP BY movimiento_revertido_id HAVING count(*)>1) b
+    UNION ALL SELECT count(*) FROM (SELECT movimiento_revertido_id FROM movimientos_stock WHERE movimiento_revertido_id IS NOT NULL GROUP BY movimiento_revertido_id HAVING count(*)>1) c
+) q;
+"@
+
+    $cashNet = Invoke-Sql -Query @"
+SELECT COALESCE(sum(CASE mc.tipo
+    WHEN 'INGRESO_PAGO' THEN mc.importe
+    WHEN 'AJUSTE_INGRESO' THEN mc.importe
+    WHEN 'EGRESO' THEN -mc.importe
+    WHEN 'AJUSTE_EGRESO' THEN -mc.importe
+    WHEN 'REVERSO' THEN CASE WHEN original.tipo IN ('INGRESO_PAGO','AJUSTE_INGRESO') THEN -mc.importe ELSE mc.importe END
+    ELSE 0 END),0)::text
+FROM movimientos_caja mc
+LEFT JOIN movimientos_caja original ON original.id=mc.movimiento_revertido_id
+WHERE mc.idempotency_key LIKE 'demo-seed:v1:%';
+"@
+    Add-Result -Stage "Caja demo conciliable" -Result "PASS" -Detail "saldo neto=$cashNet"
+}
+
+function Show-Diagnostics {
+    try {
+        $composePs = Invoke-Compose -Arguments @("ps", "-a") -Capture -IgnoreDeadline
+        if ($composePs) { Write-Host (Redact $composePs) }
+    }
+    catch { Write-Host "No se pudo obtener docker compose ps." }
+
+    try {
+        $dbLogs = Invoke-Compose -Arguments @("logs", "--tail", "120", "db") -Capture -IgnoreDeadline
+        if ($dbLogs) { Write-Host (Redact $dbLogs) }
+    }
+    catch { Write-Host "No se pudieron obtener logs de PostgreSQL." }
+
+    $backendTail = Get-BackendLogTail
+    if (-not [string]::IsNullOrWhiteSpace($backendTail)) {
+        Write-Host $backendTail
+    }
+}
+
+function Remove-IsolatedDockerResources {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { return }
+
+    try { Invoke-Compose -Arguments @("down", "--volumes", "--remove-orphans", "--timeout", "10") -IgnoreDeadline | Out-Null }
+    catch { Write-Host "[WARN] docker compose down falló: $(Redact $_.Exception.Message)" }
+
+    try {
+        $containers = Invoke-Docker -Arguments @("ps", "-aq", "--filter", "label=com.docker.compose.project=$($script:project)") -Capture -IgnoreDeadline
+        foreach ($id in @($containers -split "`r?`n" | Where-Object { $_ })) {
+            try { Invoke-Docker -Arguments @("rm", "-f", $id) -IgnoreDeadline | Out-Null } catch { }
+        }
+    }
+    catch { }
+
+    try {
+        $networks = Invoke-Docker -Arguments @("network", "ls", "-q", "--filter", "label=com.docker.compose.project=$($script:project)") -Capture -IgnoreDeadline
+        foreach ($id in @($networks -split "`r?`n" | Where-Object { $_ })) {
+            try { Invoke-Docker -Arguments @("network", "rm", $id) -IgnoreDeadline | Out-Null } catch { }
+        }
+    }
+    catch { }
+
+    try {
+        $volumes = Invoke-Docker -Arguments @("volume", "ls", "-q", "--filter", "label=com.docker.compose.project=$($script:project)") -Capture -IgnoreDeadline
+        foreach ($id in @($volumes -split "`r?`n" | Where-Object { $_ })) {
+            try { Invoke-Docker -Arguments @("volume", "rm", "-f", $id) -IgnoreDeadline | Out-Null } catch { }
+        }
+    }
+    catch { }
+
+    $remainingContainers = Invoke-Docker -Arguments @("ps", "-aq", "--filter", "label=com.docker.compose.project=$($script:project)") -Capture -IgnoreDeadline
+    $remainingNetworks = Invoke-Docker -Arguments @("network", "ls", "-q", "--filter", "label=com.docker.compose.project=$($script:project)") -Capture -IgnoreDeadline
+    $remainingVolumes = Invoke-Docker -Arguments @("volume", "ls", "-q", "--filter", "label=com.docker.compose.project=$($script:project)") -Capture -IgnoreDeadline
+    if (-not [string]::IsNullOrWhiteSpace($remainingContainers) -or
+        -not [string]::IsNullOrWhiteSpace($remainingNetworks) -or
+        -not [string]::IsNullOrWhiteSpace($remainingVolumes)) {
+        throw "Quedaron recursos Docker del proyecto aislado"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path $tempRoot, $receiptsRoot -Force | Out-Null
+
+    $parseTokens = $null
+    $parseErrors = $null
+    [void][System.Management.Automation.Language.Parser]::ParseFile(
+        $PSCommandPath,
+        [ref]$parseTokens,
+        [ref]$parseErrors
+    )
+    if ($parseErrors.Count -gt 0) {
+        $messages = ($parseErrors | ForEach-Object { $_.Message }) -join "; "
+        throw "El propio script no supera el parser de PowerShell: $messages"
+    }
+    Add-Result -Stage "Sintaxis PowerShell" -Result "PASS" -Detail "Parser nativo sin errores"
+
+    foreach ($required in @($composeFile, $seedPath, $migrationRoot, $backendRoot)) {
+        if (-not (Test-Path -LiteralPath $required)) { throw "Falta recurso requerido: $required" }
+    }
+    Add-Result -Stage "Estructura del repositorio" -Result "PASS" -Detail "Compose, backend, migraciones y seed presentes"
+    Assert-SeedStaticContract
+
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) { throw "Docker no está disponible en PATH" }
+    Invoke-Docker -Arguments @("info", "--format", "{{.ServerVersion}}") -Capture | Out-Null
+    Invoke-Docker -Arguments @("compose", "version") -Capture | Out-Null
+    Add-Result -Stage "Docker" -Result "PASS" -Detail "Engine y Compose disponibles"
+
+    $jdk = Resolve-Java21
+    $javaHome = $jdk.Home
+    $javaExe = $jdk.Java
+    $javacExe = $jdk.Javac
+    Set-ScopedEnvironmentVariable -Name "JAVA_HOME" -Value $javaHome
+    $pathSeparator = [IO.Path]::PathSeparator
+    Set-ScopedEnvironmentVariable -Name "PATH" -Value ((Join-Path $javaHome "bin") + $pathSeparator + $env:PATH)
+    $javaVersion = Invoke-Native -FilePath $javaExe -Arguments @("-version") -Capture
+    Add-Result -Stage "Java 21" -Result "PASS" -Detail (($javaVersion -split "`r?`n")[0])
+
+    $mavenWrapper = Resolve-MavenWrapper
+    if (-not $SkipBackendBuild) {
+        Build-Backend
+        Add-Result -Stage "Build backend" -Result "PASS" -Detail ([IO.Path]::GetFileName($backendJar))
+    }
+    else {
+        $jars = @(Get-ChildItem -LiteralPath (Join-Path $backendRoot "target") -Filter "*.jar" -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -notlike "*.original" } |
+            Sort-Object Length -Descending)
+        if ($jars.Count -eq 0) { throw "-SkipBackendBuild requiere un JAR existente en backend/target" }
+        $backendJar = $jars[0].FullName
+        Add-Result -Stage "Build backend" -Result "INFO" -Detail "Se reutilizó $([IO.Path]::GetFileName($backendJar))"
+    }
+
+    $dbPort = Get-FreePort
+    $backendPort = Get-FreePort
+    $frontendPort = Get-FreePort
+    $apiBase = "http://127.0.0.1:$backendPort/api"
+    $frontendOrigin = "http://127.0.0.1:$frontendPort"
+    $anchorDate = Get-BusinessDate
+    $postgresPassword = New-HexSecret 24
+    $jwtSecret = New-HexSecret 64
+    Add-Secret $postgresPassword
+    Add-Secret $jwtSecret
+
+    Set-ScopedEnvironmentVariable -Name "POSTGRES_DB" -Value $postgresDb
+    Set-ScopedEnvironmentVariable -Name "POSTGRES_USER" -Value $postgresUser
+    Set-ScopedEnvironmentVariable -Name "POSTGRES_PASSWORD" -Value $postgresPassword
+    Set-ScopedEnvironmentVariable -Name "POSTGRES_PORT" -Value ([string]$dbPort)
+    Set-ScopedEnvironmentVariable -Name "APP_TIME_ZONE" -Value "America/Argentina/Buenos_Aires"
+    Configure-BackendEnvironment
+
+    Write-Host "[INFO] Proyecto Compose aislado: $project"
+    Write-Host "[INFO] Puertos aleatorios: PostgreSQL=$dbPort backend=$backendPort"
+    Write-Host "[INFO] Fecha ancla: $($anchorDate.ToString('yyyy-MM-dd'))"
+
+    $stackAttempted = $true
+    Invoke-Compose -Arguments @("up", "-d", "db")
+    Wait-DatabaseHealthy
+    Add-Result -Stage "PostgreSQL efímero" -Result "PASS" -Detail "Base $postgresDb healthy en puerto aleatorio"
+
+    $cookieContainer = [Net.CookieContainer]::new()
+    $handler = [Net.Http.HttpClientHandler]::new()
+    $handler.CookieContainer = $cookieContainer
+    $http = [Net.Http.HttpClient]::new($handler, $true)
+    $http.Timeout = [TimeSpan]::FromSeconds(30)
+
+    Start-Backend
+    Wait-BackendAvailable
+    Add-Result -Stage "Flyway mediante backend real" -Result "PASS" -Detail "Backend inició con ddl-auto=validate"
+
+    $history = Invoke-Sql -Query "SELECT installed_rank, COALESCE(version,''), description, type, script, COALESCE(checksum::text,''), success FROM flyway_schema_history ORDER BY installed_rank;"
+    Assert-Equal -Actual (Invoke-Sql "SELECT count(*) FROM flyway_schema_history WHERE script='V6__rbac_permission_catalog_and_base_roles.sql' AND success") -Expected "1" -Message "La V6 productiva no fue aplicada"
+    Assert-Equal -Actual (Invoke-Sql "SELECT count(*) FROM flyway_schema_history WHERE NOT success") -Expected "0" -Message "Flyway contiene migraciones fallidas"
+    Assert-Equal -Actual (Invoke-Sql "SELECT count(*) FROM flyway_schema_history WHERE lower(script) LIKE '%demo%seed%'") -Expected "0" -Message "Se detectó una migración Flyway demo"
+
+    $localMigrations = @(Get-ChildItem -LiteralPath $migrationRoot -Filter "V*__*.sql" -File | Sort-Object Name)
+    $demoMigrations = @($localMigrations | Where-Object { $_.Name -match '(?i)demo.*seed|seed.*demo' })
+    Assert-Equal -Actual $demoMigrations.Count -Expected 0 -Message "Existe una migración demo en db/migration"
+    $historyScripts = @((Invoke-Sql "SELECT script FROM flyway_schema_history WHERE success ORDER BY installed_rank;") -split "`r?`n")
+    foreach ($migration in $localMigrations) {
+        Assert-True -Condition ($historyScripts -contains $migration.Name) -Message "Flyway no aplicó $($migration.Name)"
+    }
+    Add-Result -Stage "Historial Flyway" -Result "PASS" -Detail "$($localMigrations.Count) migraciones reales; V6 productiva presente; ninguna demo"
+    Write-Host "[INFO] flyway_schema_history:`n$history"
+
+    $rbacBefore = Get-RbacSnapshot
+    Assert-Equal -Actual (Invoke-Sql "SELECT count(*) FROM permisos WHERE activo AND sistema") -Expected "32" -Message "Catálogo RBAC productivo inesperado"
+    Assert-Equal -Actual (Invoke-Sql "SELECT count(*) FROM roles WHERE codigo='PROFESOR' AND NOT activo AND sistema AND NOT editable") -Expected "1" -Message "PROFESOR no mantiene su contrato productivo"
+    Add-Result -Stage "Baseline RBAC" -Result "PASS" -Detail "32 permisos activos y rol Profesor deshabilitado"
+
+    Stop-Backend
+
+    $script:demoPasswords = @{
+        "demo-superadmin" = New-HexSecret 24
+        "demo-direccion" = New-HexSecret 24
+        "demo-administrador" = New-HexSecret 24
+        "demo-secretaria" = New-HexSecret 24
+        "demo-caja" = New-HexSecret 24
+    }
+    foreach ($password in $script:demoPasswords.Values) { Add-Secret $password }
+    Assert-True -Condition ($script:demoPasswords["demo-superadmin"].Length -ge 16) -Message "Password técnica demasiado corta"
+    $script:demoHashes = New-BcryptHashes -Passwords $script:demoPasswords
+    Add-Result -Stage "Credenciales efímeras" -Result "PASS" -Detail "5 passwords en memoria y 5 hashes BCrypt del backend"
+
+    Invoke-DemoSeed | Out-Null
+    foreach ($username in @($script:demoPasswords.Keys | Sort-Object)) {
+        $storedHash = Invoke-Sql "SELECT contrasena FROM usuarios WHERE lower(nombre_usuario)='$username';"
+        Add-Secret $storedHash
+        Assert-Equal -Actual $storedHash -Expected $script:demoHashes[$username] -Message "El hash persistido no corresponde a $username"
+    }
+    $snapshotFirstRaw = Get-DemoSnapshot
+    $snapshotFirst = $snapshotFirstRaw | ConvertFrom-Json
+    Assert-ExpectedDemoCounts -Snapshot $snapshotFirst
+    $rbacAfterFirst = Get-RbacSnapshot
+    Assert-Equal -Actual $rbacAfterFirst -Expected $rbacBefore -Message "El seed modificó RBAC"
+    Add-Result -Stage "Primera aplicación del seed" -Result "PASS" -Detail "Conteos esperados e invariantes internas satisfechas"
+
+    Start-Backend
+    Wait-BackendAvailable
+    Add-Result -Stage "Backend sobre dataset demo" -Result "PASS" -Detail "Hibernate validate y Flyway sin cambios"
+
+    Invoke-Api -Method "GET" -Path "/usuarios/perfil" -Token $null -ExpectedStatus 401 | Out-Null
+    Add-Result -Stage "Health/autenticación anónima" -Result "PASS" -Detail "Backend disponible; perfil anónimo=401"
+
+    $rolesEsperados = [ordered]@{
+        "demo-superadmin" = "SUPERADMIN"
+        "demo-direccion" = "DIRECCION"
+        "demo-administrador" = "ADMINISTRADOR"
+        "demo-secretaria" = "SECRETARIA"
+        "demo-caja" = "CAJA"
+    }
+    foreach ($entry in $rolesEsperados.GetEnumerator()) {
+        $user = Login-Actor -Username $entry.Key -ExpectedRole $entry.Value
+        Assert-Equal -Actual ([string]$user.nombreUsuario) -Expected $entry.Key -Message "Username de login incorrecto"
+    }
+    Add-Result -Stage "Login de usuarios demo" -Result "PASS" -Detail "5/5 actores autenticados"
+
+    $superToken = $actorTokens["demo-superadmin"]
+    $profile = Invoke-Api -Method "GET" -Path "/usuarios/perfil" -Token $superToken -ExpectedStatus 200
+    Assert-True -Condition (@($profile.Json.permisos).Count -eq 32) -Message "Perfil técnico sin catálogo completo"
+    $assignable = Invoke-Api -Method "GET" -Path "/usuarios/roles-asignables" -Token $superToken -ExpectedStatus 200
+    Assert-True -Condition (@($assignable.Json.codigo) -notcontains "PROFESOR") -Message "PROFESOR aparece como rol asignable"
+    Add-Result -Stage "Perfil y roles asignables" -Result "PASS" -Detail "32 permisos; Profesor no asignable"
+
+    $ids = Invoke-Sql -Query @"
+SELECT a.id, i.id
+FROM alumnos a
+JOIN inscripciones i ON i.alumno_id=a.id AND i.estado='ACTIVA'
+WHERE a.documento='DEMO-DNI-A001'
+ORDER BY i.id LIMIT 1;
+"@
+    $idParts = $ids.Split("|")
+    Assert-Equal -Actual $idParts.Count -Expected 2 -Message "No se resolvieron IDs demo representativos"
+    $alumnoId = [long]$idParts[0]
+    $inscripcionId = [long]$idParts[1]
+    $reportFrom = $anchorDate.AddMonths(-3).ToString("yyyy-MM-dd")
+    $reportTo = $anchorDate.ToString("yyyy-MM-dd")
+    $attendancePeriod = $anchorDate.AddMonths(-1)
+
+    foreach ($endpoint in @(
+        @{ Name="Alumnos"; Path="/alumnos?page=0&size=5" },
+        @{ Name="Disciplinas"; Path="/disciplinas" },
+        @{ Name="Profesores"; Path="/profesores" },
+        @{ Name="Inscripciones"; Path="/inscripciones?page=0&size=5" },
+        @{ Name="Mensualidades"; Path="/mensualidades/inscripcion/$inscripcionId" },
+        @{ Name="Cargos"; Path="/cargos/alumno/$alumnoId/pendientes?page=0&size=5" },
+        @{ Name="Pagos"; Path="/pagos/alumno/${alumnoId}?page=0&size=5" },
+        @{ Name="Caja"; Path="/caja/resumen?desde=$reportFrom&hasta=$reportTo&page=0&size=5" },
+        @{ Name="Stock"; Path="/stocks?page=0&size=5" },
+        @{ Name="Asistencias"; Path="/asistencias-mensuales?mes=$($attendancePeriod.Month)&anio=$($attendancePeriod.Year)" },
+        @{ Name="Reportes"; Path="/reportes/mensualidades?desde=$reportFrom&hasta=$reportTo" },
+        @{ Name="Configuración"; Path="/metodos-pago" },
+        @{ Name="Usuarios"; Path="/usuarios" },
+        @{ Name="Roles"; Path="/roles" }
+    )) {
+        Assert-Endpoint -Stage "Endpoint $($endpoint.Name)" -Method "GET" -Path $endpoint.Path -Actor "demo-superadmin" -ExpectedStatus 200
+    }
+
+    Assert-Endpoint -Stage "Dirección administra usuarios" -Method "GET" -Path "/usuarios" -Actor "demo-direccion" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Dirección no administra roles" -Method "GET" -Path "/roles" -Actor "demo-direccion" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Administrador administra usuarios" -Method "GET" -Path "/usuarios" -Actor "demo-administrador" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Administrador no administra roles" -Method "GET" -Path "/roles" -Actor "demo-administrador" -ExpectedStatus 403
+
+    Assert-Endpoint -Stage "Secretaría consulta alumnos" -Method "GET" -Path "/alumnos?page=0&size=1" -Actor "demo-secretaria" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Secretaría consulta inscripciones" -Method "GET" -Path "/inscripciones?page=0&size=1" -Actor "demo-secretaria" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Secretaría consulta asistencias" -Method "GET" -Path "/asistencias-mensuales?mes=$($attendancePeriod.Month)&anio=$($attendancePeriod.Year)" -Actor "demo-secretaria" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Secretaría consulta reportes" -Method "GET" -Path "/reportes/mensualidades?desde=$reportFrom&hasta=$reportTo" -Actor "demo-secretaria" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Secretaría autoriza registro de pago" -Method "POST" -Path "/pagos" -Actor "demo-secretaria" -ExpectedStatus 400 -Body @{}
+    Assert-Endpoint -Stage "Secretaría autoriza registro de asistencia" -Method "POST" -Path "/asistencias-mensuales" -Actor "demo-secretaria" -ExpectedStatus 400 -Body @{}
+    Assert-Endpoint -Stage "Secretaría no administra usuarios" -Method "GET" -Path "/usuarios" -Actor "demo-secretaria" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Secretaría no administra roles" -Method "GET" -Path "/roles" -Actor "demo-secretaria" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Secretaría no administra egresos" -Method "GET" -Path "/egresos?page=0&size=1" -Actor "demo-secretaria" -ExpectedStatus 403
+
+    Assert-Endpoint -Stage "Caja consulta alumnos" -Method "GET" -Path "/alumnos?page=0&size=1" -Actor "demo-caja" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Caja consulta pagos" -Method "GET" -Path "/pagos/alumno/${alumnoId}?page=0&size=1" -Actor "demo-caja" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Caja consulta caja" -Method "GET" -Path "/caja/resumen?desde=$reportFrom&hasta=$reportTo&page=0&size=1" -Actor "demo-caja" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Caja consulta stock" -Method "GET" -Path "/stocks?page=0&size=1" -Actor "demo-caja" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Caja consulta configuración" -Method "GET" -Path "/metodos-pago" -Actor "demo-caja" -ExpectedStatus 200
+    Assert-Endpoint -Stage "Caja autoriza registro de pago" -Method "POST" -Path "/pagos" -Actor "demo-caja" -ExpectedStatus 400 -Body @{}
+    Assert-Endpoint -Stage "Caja no administra egresos por escritura" -Method "POST" -Path "/egresos" -Actor "demo-caja" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Caja no consulta inscripciones" -Method "GET" -Path "/inscripciones?page=0&size=1" -Actor "demo-caja" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Caja no consulta reportes" -Method "GET" -Path "/reportes/mensualidades?desde=$reportFrom&hasta=$reportTo" -Actor "demo-caja" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Caja no consulta profesores" -Method "GET" -Path "/profesores" -Actor "demo-caja" -ExpectedStatus 403
+    Assert-Endpoint -Stage "Caja no administra egresos" -Method "GET" -Path "/egresos?page=0&size=1" -Actor "demo-caja" -ExpectedStatus 403
+
+    Invoke-IntegrityChecks
+    $rbacAfterHttp = Get-RbacSnapshot
+    Assert-Equal -Actual $rbacAfterHttp -Expected $rbacBefore -Message "Los smoke HTTP modificaron RBAC"
+    Add-Result -Stage "RBAC tras smoke HTTP" -Result "PASS" -Detail "Catálogo y matrices sin cambios"
+
+    Stop-Backend
+    Invoke-DemoSeed | Out-Null
+    $snapshotSecondRaw = Get-DemoSnapshot
+    $snapshotSecond = $snapshotSecondRaw | ConvertFrom-Json
+    Assert-ExpectedDemoCounts -Snapshot $snapshotSecond
+    Assert-Equal -Actual $snapshotSecondRaw -Expected $snapshotFirstRaw -Message "La segunda ejecución cambió conteos, IDs o totales"
+    Assert-Equal -Actual (Get-RbacSnapshot) -Expected $rbacBefore -Message "La segunda ejecución modificó RBAC"
+    Add-Result -Stage "Segunda aplicación del seed" -Result "PASS" -Detail "Idempotencia completa; snapshot idéntico"
+
+    Start-Backend
+    Wait-BackendAvailable
+    $actorTokens.Clear()
+    Login-Actor -Username "demo-superadmin" -ExpectedRole "SUPERADMIN" | Out-Null
+    Invoke-Api -Method "GET" -Path "/usuarios/perfil" -Token $actorTokens["demo-superadmin"] -ExpectedStatus 200 | Out-Null
+    Add-Result -Stage "Login posterior a reejecución" -Result "PASS" -Detail "Backend y credenciales continúan operativos"
+
+    Stop-Backend
+    Assert-NoSecretsInTemporaryFiles
+    Add-Result -Stage "Validación integral" -Result "PASS" -Detail "Seed reproducible, autorizaciones y datos consistentes"
+}
+catch {
+    $exitCode = 1
+    $caughtMessage = Redact $_.Exception.Message
+    Add-Result -Stage "Validación integral" -Result "FAIL" -Detail $caughtMessage
+    Show-Diagnostics
+}
+finally {
+    try { Stop-Backend } catch { }
+    if ($null -ne $http) {
+        try { $http.Dispose() } catch { }
+        $http = $null
+    }
+
+    if ($stackAttempted) {
+        try {
+            Remove-IsolatedDockerResources
+            Add-Result -Stage "Limpieza Docker" -Result "PASS" -Detail "Contenedores, red y volúmenes aislados eliminados"
+        }
+        catch {
+            if ($exitCode -eq 0) { $exitCode = 1 }
+            Add-Result -Stage "Limpieza Docker" -Result "FAIL" -Detail (Redact $_.Exception.Message)
+        }
+    }
+
+    try {
+        if (Test-Path -LiteralPath $tempRoot) {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force
+        }
+        Add-Result -Stage "Limpieza temporal" -Result "PASS" -Detail "Archivos auxiliares eliminados"
+    }
+    catch {
+        if ($exitCode -eq 0) { $exitCode = 1 }
+        Add-Result -Stage "Limpieza temporal" -Result "FAIL" -Detail (Redact $_.Exception.Message)
+    }
+
+    try { Restore-Environment }
+    catch {
+        if ($exitCode -eq 0) { $exitCode = 1 }
+        Add-Result -Stage "Restauración de entorno" -Result "FAIL" -Detail (Redact $_.Exception.Message)
+    }
+
+    $script:demoPasswords.Clear()
+    $script:demoHashes.Clear()
+    $actorTokens.Clear()
+    $secretValues.Clear()
+    $postgresPassword = $null
+    $jwtSecret = $null
+}
+
+Write-Host ""
+Write-Host "Resumen de validación" -ForegroundColor Cyan
+$results | Format-Table -AutoSize Etapa, Resultado, Detalle
+Write-Host "Duración: $([math]::Round(((Get-Date) - $startedAt).TotalSeconds, 1)) segundos"
+
+if ($exitCode -ne 0) {
+    $finalError = if ([string]::IsNullOrWhiteSpace($caughtMessage)) { "La validación del seed demo falló" } else { $caughtMessage }
+    [Console]::Error.WriteLine($finalError)
+    exit $exitCode
+}
+exit 0


### PR DESCRIPTION
## Qué cambia

- reemplaza el seed demo anterior por un SQL manual, transaccional e idempotente fuera de Flyway;
- preserva el catálogo y las matrices RBAC definidos por V6;
- agrega un validador aislado para Flyway, Hibernate, integridad, reejecución, secretos y permisos HTTP;
- documenta el flujo soportado de ejecución local.

## Por qué

El seed anterior se presentaba como una V6 alternativa, redefinía RBAC, contenía credenciales conocidas y fabricaba datos derivados que pertenecen a servicios productivos. Eso podía divergir del contrato real de autorización y de la trazabilidad de la aplicación.

## Impacto

El nuevo dataset carga 914 filas ficticias en una base descartable, genera cinco credenciales efímeras y cubre academia, finanzas, caja, crédito, stock, asistencias y recibos. No modifica migraciones productivas y no es apto para producción.

## Validación

- `backend\mvnw.cmd clean verify`: 129 tests, 0 fallos;
- `npm ci`, `npm run lint`, `npm test`, `npm run build`: 140 tests frontend y build verde;
- `scripts\codex\validate.ps1 -Scope All`: PASS;
- `scripts\smoke-local.ps1`: 20/20, PASS;
- `scripts\validate-demo-seed.ps1`: 75 etapas PASS, dos aplicaciones idénticas, RBAC intacto y cleanup completo;
- `git diff --check`: PASS.
